### PR TITLE
Update API endpoint for fetching upcoming events

### DIFF
--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -18,7 +18,7 @@
       isLoading.set(true);
 
       // In a real app, this would be an API call
-      const response = await fetch("/api/events?limit=6&upcoming=true");
+      const response = await fetch("/api/events/upcoming?limit=6");
       if (response.ok) {
         const result = await response.json();
         const apiEvents = result.success ? result.data : [];


### PR DESCRIPTION
This pull request makes a small update to the way upcoming events are fetched in the `Home.svelte` page. The API endpoint has been changed to a more RESTful path.

- Changed the fetch URL in `Home.svelte` to use `/api/events/upcoming?limit=6` instead of `/api/events?limit=6&upcoming=true` for retrieving upcoming events.