### PR TITLE
Enhance event management with boolean validation and new endpoints

### DIFF
--- a/backend/api/admin.php
+++ b/backend/api/admin.php
@@ -202,6 +202,8 @@ try {
         AdminEventsController::patchStatus($id);
         return;
       }
+      Response::error('Method not allowed', 405);
+      return;
     } elseif (preg_match('#^/events/([a-zA-Z0-9\-]+)$#', $path, $matches)) {
       $id = (string)$matches[1];
       if ($method === 'PUT') {

--- a/backend/api/admin.php
+++ b/backend/api/admin.php
@@ -196,6 +196,12 @@ try {
         AdminEventsController::create();
         return;
       }
+    } elseif (preg_match('#^/events/([a-zA-Z0-9\-]+)/status$#', $path, $matches)) {
+      $id = (string)$matches[1];
+      if ($method === 'PATCH') {
+        AdminEventsController::patchStatus($id);
+        return;
+      }
     } elseif (preg_match('#^/events/([a-zA-Z0-9\-]+)$#', $path, $matches)) {
       $id = (string)$matches[1];
       if ($method === 'PUT') {

--- a/backend/migrations/010_add_event_end_datetime_index.sql
+++ b/backend/migrations/010_add_event_end_datetime_index.sql
@@ -1,0 +1,5 @@
+-- Migration 010: Add index on events.end_datetime
+-- Needed after switching upcoming/featured filters from start_datetime to end_datetime
+-- to prevent full table scans on those queries.
+
+ALTER TABLE events ADD INDEX idx_end_datetime (end_datetime);

--- a/backend/src/Controllers/AdminEventsController.php
+++ b/backend/src/Controllers/AdminEventsController.php
@@ -244,7 +244,7 @@ class AdminEventsController
             $result = Database::fetchOne($checkSql, [$id, $id]);
 
             if (!$result) {
-                Response::notFound(['message' => 'Event not found']);
+                Response::notFound(['message' => 'Event or series not found']);
                 return;
             }
 

--- a/backend/src/Controllers/AdminEventsController.php
+++ b/backend/src/Controllers/AdminEventsController.php
@@ -238,17 +238,17 @@ class AdminEventsController
         }
 
         try {
-            $checkSql = "SELECT 'event' as type FROM events WHERE id = ?
-                         UNION
-                         SELECT 'series' as type FROM event_series WHERE id = ?";
-            $result = Database::fetchOne($checkSql, [$id, $id]);
+            // Check events first, then series — sequential to avoid UNION
+            // returning an arbitrary row if the same UUID existed in both tables.
+            $isEvent = Database::fetchOne("SELECT id FROM events WHERE id = ?", [$id]);
+            $isSeries = !$isEvent && Database::fetchOne("SELECT id FROM event_series WHERE id = ?", [$id]);
 
-            if (!$result) {
+            if (!$isEvent && !$isSeries) {
                 Response::notFound(['message' => 'Event or series not found']);
                 return;
             }
 
-            if ($result['type'] === 'series') {
+            if ($isSeries) {
                 if (!in_array($status, $allowedSeriesStatuses, true)) {
                     Response::error('Series status must be one of: ' . implode(', ', $allowedSeriesStatuses), 400);
                     return;

--- a/backend/src/Controllers/AdminEventsController.php
+++ b/backend/src/Controllers/AdminEventsController.php
@@ -266,7 +266,9 @@ class AdminEventsController
 
             Response::success(['status' => $status], 'Status updated successfully');
         } catch (Exception $e) {
-            Response::error('Failed to update status: ' . $e->getMessage(), 500);
+            error_log('[patchStatus] Exception: ' . $e->getMessage());
+            $debug = \HypnoseStammtisch\Config\Config::get('app.debug', false);
+            Response::error($debug ? 'Failed to update status: ' . $e->getMessage() : 'Failed to update status', 500);
         }
     }
 

--- a/backend/src/Controllers/AdminEventsController.php
+++ b/backend/src/Controllers/AdminEventsController.php
@@ -204,6 +204,68 @@ class AdminEventsController
     }
 
     /**
+     * Update only the status of an event or series (PATCH)
+     */
+    public static function patchStatus(string $id): void
+    {
+        AdminAuth::requireAuth();
+        AdminAuth::requireCSRF();
+        $user = AdminAuth::getCurrentUser();
+        if (!AdminAuth::userHasRole($user, AdminAuth::EVENT_MANAGEMENT_ROLES)) {
+            Response::error('Insufficient permissions', 403);
+            return;
+        }
+
+        if ($_SERVER['REQUEST_METHOD'] !== 'PATCH') {
+            Response::error('Method not allowed', 405);
+            return;
+        }
+
+        $input = json_decode(file_get_contents('php://input'), true) ?? [];
+        $status = $input['status'] ?? null;
+
+        $allowedEventStatuses = ['draft', 'published', 'cancelled', 'completed'];
+        $allowedSeriesStatuses = ['draft', 'published', 'cancelled'];
+
+        if (!in_array($status, $allowedEventStatuses, true)) {
+            Response::error('Invalid status. Must be one of: ' . implode(', ', $allowedEventStatuses), 400);
+            return;
+        }
+
+        try {
+            $checkSql = "SELECT 'event' as type FROM events WHERE id = ?
+                         UNION
+                         SELECT 'series' as type FROM event_series WHERE id = ?";
+            $result = Database::fetchOne($checkSql, [$id, $id]);
+
+            if (!$result) {
+                Response::notFound(['message' => 'Event not found']);
+                return;
+            }
+
+            if ($result['type'] === 'series') {
+                if (!in_array($status, $allowedSeriesStatuses, true)) {
+                    Response::error('Series status must be one of: ' . implode(', ', $allowedSeriesStatuses), 400);
+                    return;
+                }
+                Database::execute(
+                    "UPDATE event_series SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    [$status, $id]
+                );
+            } else {
+                Database::execute(
+                    "UPDATE events SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    [$status, $id]
+                );
+            }
+
+            Response::success(['status' => $status], 'Status updated successfully');
+        } catch (Exception $e) {
+            Response::error('Failed to update status: ' . $e->getMessage(), 500);
+        }
+    }
+
+    /**
      * Create single event
      */
     private static function createSingleEvent(array $input): void

--- a/backend/src/Controllers/AdminEventsController.php
+++ b/backend/src/Controllers/AdminEventsController.php
@@ -221,7 +221,12 @@ class AdminEventsController
             return;
         }
 
-        $input = json_decode(file_get_contents('php://input'), true) ?? [];
+        $decoded = json_decode(file_get_contents('php://input'), true);
+        if (!is_array($decoded)) {
+            Response::error('Invalid JSON body', 400);
+            return;
+        }
+        $input = $decoded;
         $status = $input['status'] ?? null;
 
         $allowedEventStatuses = ['draft', 'published', 'cancelled', 'completed'];

--- a/backend/src/Models/Event.php
+++ b/backend/src/Models/Event.php
@@ -121,7 +121,7 @@ class Event
         try {
             $sql = "SELECT * FROM events
                     WHERE status = 'published'
-                    AND end_datetime > NOW()
+                    AND end_datetime > UTC_TIMESTAMP()
                     ORDER BY start_datetime ASC
                     LIMIT ?";
 
@@ -145,7 +145,7 @@ class Event
             $sql = "SELECT * FROM events
                     WHERE status = 'published'
                     AND is_featured = 1
-                    AND end_datetime > NOW()
+                    AND end_datetime > UTC_TIMESTAMP()
                     ORDER BY start_datetime ASC
                     LIMIT ?";
 

--- a/backend/src/Models/Event.php
+++ b/backend/src/Models/Event.php
@@ -121,7 +121,7 @@ class Event
         try {
             $sql = "SELECT * FROM events
                     WHERE status = 'published'
-                    AND start_datetime > NOW()
+                    AND end_datetime > NOW()
                     ORDER BY start_datetime ASC
                     LIMIT ?";
 
@@ -145,7 +145,7 @@ class Event
             $sql = "SELECT * FROM events
                     WHERE status = 'published'
                     AND is_featured = 1
-                    AND start_datetime > NOW()
+                    AND end_datetime > NOW()
                     ORDER BY start_datetime ASC
                     LIMIT ?";
 

--- a/src/pages/admin/AdminEvents.svelte
+++ b/src/pages/admin/AdminEvents.svelte
@@ -489,6 +489,23 @@
                     </div>
 
                     <div class="flex items-center gap-2 sm:self-start">
+                      {#if event.status === "draft"}
+                        <button
+                          on:click={() =>
+                            AdminAPI.updateEventStatus(event.id, "published")}
+                          class="rounded-lg border border-green-200 dark:border-green-700 px-3 py-1 text-sm font-medium text-green-700 dark:text-green-400 transition hover:bg-green-50 dark:hover:bg-green-900/30"
+                        >
+                          Veröffentlichen
+                        </button>
+                      {:else if event.status === "published"}
+                        <button
+                          on:click={() =>
+                            AdminAPI.updateEventStatus(event.id, "draft")}
+                          class="rounded-lg border border-amber-200 dark:border-amber-700 px-3 py-1 text-sm font-medium text-amber-700 dark:text-amber-400 transition hover:bg-amber-50 dark:hover:bg-amber-900/30"
+                        >
+                          Entwurf
+                        </button>
+                      {/if}
                       <button
                         on:click={() => openEditModal(event, "event")}
                         class="rounded-lg border border-blue-100 dark:border-blue-800 px-3 py-1 text-sm font-medium text-blue-600 dark:text-blue-400 transition hover:border-blue-200 dark:hover:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/30"
@@ -569,6 +586,26 @@
                     </div>
 
                     <div class="flex items-center gap-2 sm:self-start">
+                      {#if seriesItem.status === "draft"}
+                        <button
+                          on:click={() =>
+                            AdminAPI.updateEventStatus(
+                              seriesItem.id,
+                              "published",
+                            )}
+                          class="rounded-lg border border-green-200 dark:border-green-700 px-3 py-1 text-sm font-medium text-green-700 dark:text-green-400 transition hover:bg-green-50 dark:hover:bg-green-900/30"
+                        >
+                          Veröffentlichen
+                        </button>
+                      {:else if seriesItem.status === "published"}
+                        <button
+                          on:click={() =>
+                            AdminAPI.updateEventStatus(seriesItem.id, "draft")}
+                          class="rounded-lg border border-amber-200 dark:border-amber-700 px-3 py-1 text-sm font-medium text-amber-700 dark:text-amber-400 transition hover:bg-amber-50 dark:hover:bg-amber-900/30"
+                        >
+                          Entwurf
+                        </button>
+                      {/if}
                       <button
                         on:click={() => openEditModal(seriesItem, "series")}
                         class="rounded-lg border border-blue-100 dark:border-blue-800 px-3 py-1 text-sm font-medium text-blue-600 dark:text-blue-400 transition hover:border-blue-200 dark:hover:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/30"

--- a/src/stores/admin.ts
+++ b/src/stores/admin.ts
@@ -576,13 +576,14 @@ export class AdminAPI {
     }
   }
 
-  static async updateEventStatus(id: string, status: string) {
+  static async updateEventStatus(id: string | number, status: string) {
+    const idStr = String(id);
     // Optimistic update for both events and series stores
     adminEventHelpers.updateEvent(id as any, { status });
-    adminEventHelpers.updateSeries(id, { status });
+    adminEventHelpers.updateSeries(idStr, { status });
 
     try {
-      const result = await this.request(`/events/${id}/status`, {
+      const result = await this.request(`/events/${idStr}/status`, {
         method: "PATCH",
         body: JSON.stringify({ status }),
       });

--- a/src/stores/admin.ts
+++ b/src/stores/admin.ts
@@ -577,6 +577,11 @@ export class AdminAPI {
   }
 
   static async updateEventStatus(id: string | number, status: string) {
+    // Temp events use Date.now() (number) as ID until the server responds.
+    // Real persisted events always have UUID string IDs — bail out early.
+    if (typeof id === "number") {
+      return { success: false, message: "Event not yet persisted" };
+    }
     const idStr = String(id);
     // Optimistic update — both maps are safe no-ops for non-matching IDs
     adminEventHelpers.updateEvent(idStr, { status });

--- a/src/stores/admin.ts
+++ b/src/stores/admin.ts
@@ -576,6 +576,40 @@ export class AdminAPI {
     }
   }
 
+  static async updateEventStatus(id: string, status: string) {
+    // Optimistic update for both events and series stores
+    adminEventHelpers.updateEvent(id as any, { status });
+    adminEventHelpers.updateSeries(id, { status });
+
+    try {
+      const result = await this.request(`/events/${id}/status`, {
+        method: "PATCH",
+        body: JSON.stringify({ status }),
+      });
+
+      if (result.success) {
+        const msg =
+          status === "published"
+            ? "Veranstaltung veröffentlicht!"
+            : status === "draft"
+              ? "Veranstaltung als Entwurf gespeichert."
+              : "Status aktualisiert.";
+        adminNotifications.success(msg);
+      } else {
+        this.getEvents();
+        adminNotifications.error(
+          result.message || "Fehler beim Status-Update",
+        );
+      }
+
+      return result;
+    } catch {
+      this.getEvents();
+      adminNotifications.error("Netzwerkfehler beim Status-Update");
+      return { success: false, message: "Network error" };
+    }
+  }
+
   static async deleteEvent(id: number) {
     // Optimistische Aktualisierung: Event sofort entfernen
     adminEventHelpers.removeEvent(id);

--- a/src/stores/admin.ts
+++ b/src/stores/admin.ts
@@ -598,9 +598,7 @@ export class AdminAPI {
         adminNotifications.success(msg);
       } else {
         this.getEvents();
-        adminNotifications.error(
-          result.message || "Fehler beim Status-Update",
-        );
+        adminNotifications.error(result.message || "Fehler beim Status-Update");
       }
 
       return result;

--- a/src/stores/admin.ts
+++ b/src/stores/admin.ts
@@ -580,6 +580,7 @@ export class AdminAPI {
     // Temp events use Date.now() (number) as ID until the server responds.
     // Real persisted events always have UUID string IDs — bail out early.
     if (typeof id === "number") {
+      adminNotifications.error("Veranstaltung wird noch gespeichert – bitte kurz warten.");
       return { success: false, message: "Event not yet persisted" };
     }
     const idStr = String(id);
@@ -602,13 +603,13 @@ export class AdminAPI {
               : "Status aktualisiert.";
         adminNotifications.success(msg);
       } else {
-        this.getEvents();
+        this.getEvents().catch(() => {});
         adminNotifications.error(result.error || result.message || "Fehler beim Status-Update");
       }
 
       return result;
     } catch {
-      this.getEvents();
+      this.getEvents().catch(() => {});
       adminNotifications.error("Netzwerkfehler beim Status-Update");
       return { success: false, message: "Network error" };
     }

--- a/src/stores/admin.ts
+++ b/src/stores/admin.ts
@@ -578,8 +578,8 @@ export class AdminAPI {
 
   static async updateEventStatus(id: string | number, status: string) {
     const idStr = String(id);
-    // Optimistic update for both events and series stores
-    adminEventHelpers.updateEvent(id as any, { status });
+    // Optimistic update — both maps are safe no-ops for non-matching IDs
+    adminEventHelpers.updateEvent(idStr, { status });
     adminEventHelpers.updateSeries(idStr, { status });
 
     try {
@@ -598,7 +598,7 @@ export class AdminAPI {
         adminNotifications.success(msg);
       } else {
         this.getEvents();
-        adminNotifications.error(result.message || "Fehler beim Status-Update");
+        adminNotifications.error(result.error || result.message || "Fehler beim Status-Update");
       }
 
       return result;

--- a/src/stores/adminData.ts
+++ b/src/stores/adminData.ts
@@ -2,7 +2,7 @@ import { writable } from "svelte/store";
 
 // Admin Data Stores für automatische Updates
 export interface AdminEvent {
-  id: number;
+  id: string | number;
   title: string;
   description: string;
   content: string;
@@ -73,18 +73,20 @@ export const adminEventHelpers = {
     adminEventBus.set({ type: "event", action: "create", data: event });
   },
 
-  updateEvent: (id: number, updates: Partial<AdminEvent>) => {
+  updateEvent: (id: string | number, updates: Partial<AdminEvent>) => {
+    const idStr = String(id);
     adminEvents.update((events) =>
       events.map((event) =>
-        event.id === id ? { ...event, ...updates } : event,
+        String(event.id) === idStr ? { ...event, ...updates } : event,
       ),
     );
-    adminEventBus.set({ type: "event", action: "update", id, data: updates });
+    adminEventBus.set({ type: "event", action: "update", id: id as number, data: updates });
   },
 
-  removeEvent: (id: number) => {
-    adminEvents.update((events) => events.filter((event) => event.id !== id));
-    adminEventBus.set({ type: "event", action: "delete", id });
+  removeEvent: (id: string | number) => {
+    const idStr = String(id);
+    adminEvents.update((events) => events.filter((event) => String(event.id) !== idStr));
+    adminEventBus.set({ type: "event", action: "delete", id: id as number });
   },
 
   updateSeries: (id: string, updates: Record<string, unknown>) => {

--- a/src/stores/adminData.ts
+++ b/src/stores/adminData.ts
@@ -60,7 +60,7 @@ export interface AdminUpdateEvent {
   type: "event" | "message";
   action: "create" | "update" | "delete";
   data?: any;
-  id?: number;
+  id?: string | number;
 }
 
 export const adminEventBus = writable<AdminUpdateEvent | null>(null);
@@ -80,13 +80,13 @@ export const adminEventHelpers = {
         String(event.id) === idStr ? { ...event, ...updates } : event,
       ),
     );
-    adminEventBus.set({ type: "event", action: "update", id: id as number, data: updates });
+    adminEventBus.set({ type: "event", action: "update", id, data: updates });
   },
 
   removeEvent: (id: string | number) => {
     const idStr = String(id);
     adminEvents.update((events) => events.filter((event) => String(event.id) !== idStr));
-    adminEventBus.set({ type: "event", action: "delete", id: id as number });
+    adminEventBus.set({ type: "event", action: "delete", id });
   },
 
   updateSeries: (id: string, updates: Record<string, unknown>) => {

--- a/src/stores/adminData.ts
+++ b/src/stores/adminData.ts
@@ -87,7 +87,7 @@ export const adminEventHelpers = {
     adminEventBus.set({ type: "event", action: "delete", id });
   },
 
-  updateSeries: (id: string, updates: Partial<any>) => {
+  updateSeries: (id: string, updates: Record<string, unknown>) => {
     adminSeries.update((series) =>
       series.map((s) => (s.id === id ? { ...s, ...updates } : s)),
     );

--- a/src/stores/adminData.ts
+++ b/src/stores/adminData.ts
@@ -87,6 +87,12 @@ export const adminEventHelpers = {
     adminEventBus.set({ type: "event", action: "delete", id });
   },
 
+  updateSeries: (id: string, updates: Partial<any>) => {
+    adminSeries.update((series) =>
+      series.map((s) => (s.id === id ? { ...s, ...updates } : s)),
+    );
+  },
+
   // Messages
   addMessage: (message: AdminMessage) => {
     adminMessages.update((messages) => [message, ...messages]);


### PR DESCRIPTION
This pull request introduces a new admin feature for updating the status of events and event series via a dedicated PATCH endpoint, and updates both backend and frontend code to support this. Additionally, it improves the logic for fetching upcoming and featured events and fixes a boolean parsing issue in setup. The most important changes are grouped below.

**Admin event status update feature:**

* Added a new PATCH endpoint `/events/:id/status` in `admin.php` and implemented the `patchStatus` method in `AdminEventsController` to allow admins to update the status of an event or event series. Includes validation, permission checks, and proper status options for events and series. [[1]](diffhunk://#diff-1e771b563f89a9af33741a1b7105137e3248c781bf6bc9a0758ff71164469cf2R199-R204) [[2]](diffhunk://#diff-134b86caf08c39b46c89050ab4b752abd61caf08ab2b9ca5b55207855c1bc7bdR206-R267)
* On the frontend, added `updateEventStatus` method to `AdminAPI` and UI buttons in `AdminEvents.svelte` to allow toggling event/series status between "draft" and "published" directly from the admin interface. Includes optimistic updates and notifications. [[1]](diffhunk://#diff-83091ef88a993557b2f6b984fabec83b21351128c96139891c80239159ad06c7R579-R612) [[2]](diffhunk://#diff-8b095113d933b5e1594abffade73e5d403b37df0ae507ce0a44263f17c88487dR492-R508) [[3]](diffhunk://#diff-8b095113d933b5e1594abffade73e5d403b37df0ae507ce0a44263f17c88487dR589-R608) [[4]](diffhunk://#diff-6d195b3794916d335c5b1f80700a94554b057af3179431bc3b29a3620ea01ac2R90-R95)

**Event fetching logic improvements:**

* Changed the logic for fetching upcoming and featured events in `Event.php` to use `end_datetime > NOW()` instead of `start_datetime > NOW()`, ensuring ongoing events are included. [[1]](diffhunk://#diff-9eeaea67330f5afef3c1c713885aec0309b6a6a248de4fbc2dcdb2543fc99a0aL124-R124) [[2]](diffhunk://#diff-9eeaea67330f5afef3c1c713885aec0309b6a6a248de4fbc2dcdb2543fc99a0aL148-R148)
* Updated the frontend API call in `Home.svelte` to use the new `/api/events/upcoming` endpoint.

**Other fixes:**

* Fixed boolean parsing for the `force` parameter in `SetupController` by using `filter_var` with `FILTER_VALIDATE_BOOLEAN`.