### PR TITLE
Release dev → main: Upcoming-Events-Fix (Eventserien) + Event-Ownership/Sharing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,40 @@
+# CODEOWNERS – automatische Review-Anfragen für Pull Requests
+
+# Doku: <https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners>
+
+#
+
+# Die letzte passende Regel gewinnt. Reihenfolge von allgemein -> spezifisch
+
+# Tipp: Statt einer Einzelperson kann hier auch ein Org-Team stehen
+
+# z.B. @Kink-Development-Group/maintainers
+
+# Standard-Owner für alles im Repo
+
+*                           @JosunLP
+
+# Frontend (Svelte / TypeScript)
+
+/src/                       @JosunLP
+/public/                    @JosunLP
+*.svelte                    @JosunLP
+
+# Backend (PHP)
+
+/backend/                   @JosunLP
+
+# Datenbank-Migrationen (sensibel – immer Review)
+
+/backend/migrations/        @JosunLP
+
+# CI / CD, GitHub-Konfiguration und Deployment
+
+/.github/                   @JosunLP
+/nginx.prod.conf            @JosunLP
+/scripts/                   @JosunLP
+
+# Dokumentation
+
+/docs/                      @JosunLP
+*.md                        @JosunLP

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing zu Hypnose-Stammtisch.de
+
+Vielen Dank, dass du zu Hypnose-Stammtisch.de beitragen möchtest! 🎉
+Dieser Leitfaden fasst die wichtigsten Konventionen zusammen. Eine ausführliche
+Architektur-Übersicht findest du in [`.github/copilot-instructions.md`](./copilot-instructions.md)
+und im [README](../README.md).
+
+## 📜 Verhaltenskodex
+
+Mit deiner Teilnahme akzeptierst du unseren [Code of Conduct](../CODE_OF_CONDUCT.md).
+Bitte halte die Community freundlich und respektvoll.
+
+## 🔒 Sicherheit
+
+Sicherheitslücken **niemals** als öffentliches Issue melden. Nutze stattdessen
+die vertraulichen Kanäle aus [SECURITY.md](../SECURITY.md).
+
+## 🛠️ Entwicklungsumgebung
+
+Voraussetzungen:
+
+- **Bun** (nicht Node.js) als Runtime
+- **PHP 8.1+** und **Composer**
+- **MySQL 8.0+** oder **MariaDB 10.6+**
+
+```bash
+# Frontend-Abhängigkeiten
+bun install
+
+# Backend-Abhängigkeiten
+cd backend && composer install && cd ..
+
+# Frontend (5173) + Backend (8000) parallel starten
+bun run dev
+```
+
+## 🌿 Branch- & Git-Workflow
+
+- `main` → **Produktion** (deployt automatisch via SFTP)
+- `dev` → **Beta/Staging** (deployt automatisch via SFTP)
+- Feature-Branches von `dev` abzweigen: `feature/<kurzbeschreibung>` bzw.
+  `fix/<kurzbeschreibung>`
+
+```bash
+git switch dev
+git switch -c feature/meine-funktion
+```
+
+> ⚠️ Pushes auf `dev` und `main` lösen ein automatisches Deployment aus.
+> Arbeite daher immer in Feature-Branches und gehe über Pull Requests.
+
+## ✍️ Commit-Konventionen
+
+Wir verwenden [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <kurze Beschreibung>
+```
+
+Gängige Typen: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+`chore`, `ci`. Beispiele:
+
+```
+feat(events): Serien-Bearbeitung im Admin-Panel
+fix(calendar): RRULE-Expansion über Monatsgrenzen korrigiert
+chore(deps): Tailwind auf v4.1 aktualisiert
+```
+
+## ✅ Vor dem Pull Request
+
+Bitte stelle sicher, dass folgende Befehle lokal erfolgreich durchlaufen:
+
+```bash
+bun run check        # TypeScript / Svelte
+bun run format:all   # Prettier (Frontend) + PHP-Formatierung
+bun run test         # Playwright E2E
+bun run test:a11y    # Accessibility (axe-core)
+bun run backend:test # PHPUnit (falls Backend betroffen)
+```
+
+## 🎯 Code-Konventionen (Kurzfassung)
+
+- **Dark Mode ist Pflicht**: Jedes UI-Element braucht `dark:`-Varianten.
+- **API-Aufrufe** im Frontend immer über die `AdminAPI`-Klasse (CSRF automatisch),
+  niemals mit absoluten URLs – nutze relative Pfade wie `/api/admin/events`.
+- **Admin-Seiten** bestehen aus zwei Dateien: `AdminFoo.svelte` +
+  `AdminFooGuarded.svelte` (Wrapper mit `AdminGuard`).
+- **Backend-Controller** nutzen statische Methoden, `AdminAuth::requireAuth()` /
+  `requireCSRF()` und `Response::success()` / `Response::error()`.
+- **Validierung** im Frontend mit Zod-Schemas, im Backend mit Prepared Statements.
+- **Barrierefreiheit**: WCAG 2.2 AA – Tastatur-Navigation, ARIA, Kontrast ≥ 4.5:1.
+
+## 🗄️ Datenbank-Migrationen
+
+- **Single Baseline**: `backend/migrations/001_initial_schema.sql` enthält das
+  vollständige Schema.
+- Bei Schema-Änderungen: Baseline aktualisieren (dev) bzw. neue Migration anlegen
+  (prod) und mit `bun run backend:migrate:fresh` lokal verifizieren.
+
+## 🔄 Pull-Request-Prozess
+
+1. Fülle das [Pull-Request-Template](./PULL_REQUEST_TEMPLATE.md) aus.
+2. Verlinke das zugehörige Issue (`Closes #123`).
+3. Halte den PR fokussiert und möglichst klein.
+4. Reagiere auf Review-Feedback; CI muss grün sein, bevor gemergt wird.
+
+Danke für deinen Beitrag! ❤️

--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -1,0 +1,69 @@
+name: ♿ Accessibility Issue
+description: Melde ein Barrierefreiheits-Problem (WCAG 2.2 AA).
+title: "[A11y]: "
+labels: ["accessibility", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Barrierefreiheit ist für Hypnose-Stammtisch.de ein zentrales Qualitätsziel (WCAG 2.2 AA). Danke, dass du ein Problem meldest! ♿
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Beschreibung der Barriere
+      description: Welches Element ist betroffen und warum stellt es eine Barriere dar?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tooling
+    attributes:
+      label: Genutzte Hilfsmittel / Testmethode
+      multiple: true
+      options:
+        - Tastatur-Navigation
+        - Screenreader (NVDA)
+        - Screenreader (JAWS)
+        - Screenreader (VoiceOver)
+        - Screenreader (TalkBack)
+        - Zoom / Vergrößerung (bis 200 %)
+        - Hoher Kontrast / Farbfehlsichtigkeit
+        - Reduced Motion
+        - Automatischer Test (axe-core / Lighthouse)
+    validations:
+      required: true
+
+  - type: input
+    id: wcag
+    attributes:
+      label: Betroffenes WCAG-Erfolgskriterium (optional)
+      placeholder: "z.B. 1.4.3 Kontrast (Minimum), 2.1.1 Tastatur"
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Erwartetes Verhalten
+      description: Wie sollte sich das Element barrierefrei verhalten?
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Umgebung
+      value: |
+        - Browser:
+        - Betriebssystem:
+        - Assistive Technologie + Version:
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Zusätzlicher Kontext / Screenshots
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,107 @@
+name: 🐛 Bug Report
+description: Melde einen Fehler, damit wir ihn beheben können.
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Danke, dass du dir die Zeit nimmst, einen Bug zu melden! 🙏
+        Bitte durchsuche zuerst die [bestehenden Issues](https://github.com/Kink-Development-Group/hypnose-stammtisch.de/issues), um Duplikate zu vermeiden.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Vorab-Prüfung
+      options:
+        - label: Ich habe nach ähnlichen, bereits gemeldeten Issues gesucht.
+          required: true
+        - label: Dies ist ein Bug und keine Sicherheitslücke (diese bitte vertraulich melden, siehe SECURITY.md).
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Beschreibung
+      description: Was ist passiert? Beschreibe das Problem klar und knapp.
+      placeholder: Beim Klick auf „Event speichern“ passiert nichts …
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Schritte zur Reproduktion
+      description: Wie können wir den Fehler nachstellen?
+      value: |
+        1. Gehe zu '…'
+        2. Klicke auf '…'
+        3. Scrolle zu '…'
+        4. Fehler erscheint
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Erwartetes Verhalten
+      description: Was hättest du stattdessen erwartet?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Betroffener Bereich
+      options:
+        - Frontend (Kalender / UI)
+        - Frontend (Admin-Panel)
+        - Backend / API
+        - Datenbank / Migrationen
+        - Accessibility
+        - Deployment / CI
+        - Sonstiges / unklar
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Schweregrad
+      options:
+        - Niedrig – kosmetisch / kleiner Workaround vorhanden
+        - Mittel – Funktion eingeschränkt
+        - Hoch – Funktion unbrauchbar
+        - Kritisch – Datenverlust / App nicht nutzbar
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Umgebung
+      description: Browser, OS, Gerät und ggf. App-Version / Commit.
+      value: |
+        - Browser: [z.B. Chrome 125, Safari 17]
+        - OS: [z.B. Windows 11, macOS 14, Android 14]
+        - Gerät: [z.B. Desktop, iPhone 15]
+        - Commit / Version: [z.B. main @ abc1234]
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      description: Relevante Konsolen-Ausgaben, Netzwerk-Fehler oder Screenshots. Bitte Secrets schwärzen.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Zusätzlicher Kontext
+      description: Alles, was bei der Einordnung hilft.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+# Deaktiviert leere Issues – Nutzer:innen sollen ein Template wählen.
+blank_issues_enabled: false
+
+contact_links:
+  - name: 💬 Frage oder Diskussion
+    url: https://github.com/Kink-Development-Group/hypnose-stammtisch.de/discussions
+    about: Allgemeine Fragen, Ideen und Austausch mit der Community – kein Bug-Report.
+
+  - name: 🔒 Sicherheitslücke melden (vertraulich)
+    url: https://github.com/Kink-Development-Group/hypnose-stammtisch.de/security/advisories/new
+    about: Sicherheitslücken bitte NICHT öffentlich melden. Nutze private Security Advisories – siehe SECURITY.md.
+
+  - name: 🌐 Website
+    url: https://hypnose-stammtisch.de
+    about: Zur Live-Anwendung von Hypnose-Stammtisch.de.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,75 @@
+name: ✨ Feature Request
+description: Schlage eine neue Funktion oder Verbesserung vor.
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Danke für deinen Vorschlag! 💡
+        Bitte prüfe zuerst die [bestehenden Issues](https://github.com/Kink-Development-Group/hypnose-stammtisch.de/issues) und [Diskussionen](https://github.com/Kink-Development-Group/hypnose-stammtisch.de/discussions).
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Vorab-Prüfung
+      options:
+        - label: Ich habe nach ähnlichen Vorschlägen gesucht.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: Welches Problem löst dieses Feature? Was nervt aktuell?
+      placeholder: Als Event-Manager möchte ich …, weil …
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Gewünschte Lösung
+      description: Wie sollte die Funktion idealerweise aussehen / funktionieren?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternativen
+      description: Welche anderen Ansätze hast du erwogen?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Betroffener Bereich
+      options:
+        - Frontend (Kalender / UI)
+        - Frontend (Admin-Panel)
+        - Backend / API
+        - Datenbank / Migrationen
+        - Accessibility
+        - Deployment / CI
+        - Sonstiges
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: considerations
+    attributes:
+      label: Berücksichtigungen
+      options:
+        - label: Die Funktion sollte WCAG 2.2 AA (Barrierefreiheit) wahren.
+        - label: Die Funktion benötigt Dark-Mode-Unterstützung.
+        - label: Ich bin bereit, an der Umsetzung mitzuwirken.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Zusätzlicher Kontext
+      description: Mockups, Links, Beispiele aus anderen Projekten o.Ä.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,74 @@
+<!--
+  Danke für deinen Beitrag zu Hypnose-Stammtisch.de! 🎉
+  Bitte fülle die Abschnitte aus, die für deinen PR relevant sind.
+  Abschnitte, die nicht zutreffen, kannst du löschen.
+-->
+
+## 📝 Beschreibung
+
+<!-- Was ändert dieser PR und warum? Kurz und in eigenen Worten. -->
+
+## 🔗 Verknüpfte Issues
+
+<!-- z.B. "Closes #123", "Fixes #456", "Relates to #789" -->
+
+Closes #
+
+## 🧩 Art der Änderung
+
+<!-- Zutreffendes mit "x" markieren. -->
+
+- [ ] 🐛 Bugfix (nicht-breaking, behebt ein Problem)
+- [ ] ✨ Feature (nicht-breaking, neue Funktionalität)
+- [ ] 💥 Breaking Change (Fix oder Feature, das bestehendes Verhalten ändert)
+- [ ] ♿ Accessibility (Verbesserung der Barrierefreiheit)
+- [ ] 🎨 UI / Styling (keine Logikänderung)
+- [ ] 🔧 Refactoring (kein funktionales Verhalten geändert)
+- [ ] 📝 Dokumentation
+- [ ] 🧪 Tests
+- [ ] 🔁 CI / Build / Dependencies
+
+## 🎯 Betroffene Bereiche
+
+- [ ] Frontend (`src/`)
+- [ ] Backend (`backend/`)
+- [ ] Datenbank / Migrationen
+- [ ] CI / Deployment (`.github/`)
+- [ ] Dokumentation
+
+## 🗄️ Datenbank-Migrationen
+
+<!-- Falls keine Migrationen betroffen sind, diesen Abschnitt löschen. -->
+
+- [ ] Dieser PR enthält Schema-Änderungen
+- [ ] Baseline (`backend/migrations/001_initial_schema.sql`) wurde aktualisiert (dev) **oder** eine neue Migration ergänzt (prod)
+- [ ] Fresh-Install (`bun run backend:migrate:fresh`) wurde lokal erfolgreich getestet
+
+## ✅ Checkliste
+
+- [ ] Mein Code folgt den Konventionen aus `.github/copilot-instructions.md` und `CONTRIBUTING.md`
+- [ ] Commit-Messages folgen [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:` …)
+- [ ] `bun run check` läuft fehlerfrei (TypeScript / Svelte)
+- [ ] `bun run format:all` wurde ausgeführt (Frontend + PHP)
+- [ ] `bun run test` (E2E) ist grün
+- [ ] `bun run backend:test` (PHPUnit) ist grün – sofern Backend betroffen
+- [ ] Neue UI-Elemente haben `dark:`-Varianten (Dark Mode ist Pflicht)
+- [ ] `bun run test:a11y` ist grün und WCAG 2.2 AA bleibt gewahrt (Tastatur, ARIA, Kontrast)
+- [ ] Ich habe relevante Dokumentation aktualisiert (README, `docs/`, Kommentare)
+- [ ] Keine Secrets, Tokens oder personenbezogenen Daten im Diff
+
+## 📸 Screenshots / Aufnahmen
+
+<!-- Bei UI-Änderungen: vorher/nachher. Sonst löschen. -->
+
+| Vorher | Nachher |
+| ------ | ------- |
+|        |         |
+
+## 🧪 Wie wurde getestet?
+
+<!-- Beschreibe deine Test-Schritte, Browser/Umgebung und ggf. manuelle Prüfungen. -->
+
+## 💬 Zusätzliche Hinweise
+
+<!-- Offene Fragen, Follow-ups, bewusste Trade-offs für die Reviewer. -->

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,30 @@
+# Support
+
+Danke, dass du Hypnose-Stammtisch.de nutzt! Hier findest du die richtige Anlaufstelle.
+
+## 💬 Fragen & Austausch
+
+Allgemeine Fragen, Ideen und Diskussionen gehören in die
+[GitHub Discussions](https://github.com/Kink-Development-Group/hypnose-stammtisch.de/discussions).
+
+## 🐛 Bugs & Feature-Wünsche
+
+- **Fehler gefunden?** Öffne ein [Bug-Report-Issue](https://github.com/Kink-Development-Group/hypnose-stammtisch.de/issues/new?template=bug_report.yml).
+- **Idee für ein Feature?** Öffne ein [Feature-Request-Issue](https://github.com/Kink-Development-Group/hypnose-stammtisch.de/issues/new?template=feature_request.yml).
+- **Barriere entdeckt?** Nutze das [Accessibility-Template](https://github.com/Kink-Development-Group/hypnose-stammtisch.de/issues/new?template=accessibility.yml).
+
+Bitte durchsuche vorher die [bestehenden Issues](https://github.com/Kink-Development-Group/hypnose-stammtisch.de/issues), um Duplikate zu vermeiden.
+
+## 🔒 Sicherheitsprobleme
+
+Sicherheitslücken **niemals** öffentlich melden. Folge stattdessen dem Prozess in
+[SECURITY.md](../SECURITY.md) (private Security Advisory).
+
+## 🤝 Mitmachen
+
+Du möchtest selbst beitragen? Siehe [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## 📞 Kontakt
+
+- **Website**: <https://hypnose-stammtisch.de>
+- **E-Mail**: <info@hypnose-stammtisch.de>

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,62 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot Version Updates
+# Doku: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Frontend (JavaScript/TypeScript) – Bun nutzt npm-kompatible Manifeste
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      frontend-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Backend (PHP) – Composer
+  - package-ecosystem: "composer"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "backend"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      backend-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions Workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Verhaltenskodex für Mitwirkende
+
+## Unsere Verpflichtung
+
+Wir als Mitglieder, Mitwirkende und Verantwortliche verpflichten uns, die
+Teilnahme an unserer Community für alle Menschen frei von Belästigung zu
+gestalten – unabhängig von Alter, Körpergröße, sichtbarer oder unsichtbarer
+Behinderung, ethnischer Zugehörigkeit, Geschlechtsmerkmalen, Geschlechtsidentität
+und -ausdruck, Erfahrungsstand, Bildung, sozialem Status, Nationalität,
+persönlichem Erscheinungsbild, Rasse, Religion oder sexueller Identität und
+Orientierung.
+
+Wir verpflichten uns, in einer Weise zu handeln und zu interagieren, die zu einer
+offenen, einladenden, vielfältigen, inklusiven und gesunden Community beiträgt.
+
+## Unsere Standards
+
+Beispiele für Verhalten, das zu einem positiven Umfeld beiträgt:
+
+- Empathie und Freundlichkeit gegenüber anderen Menschen zeigen
+- Unterschiedliche Meinungen, Standpunkte und Erfahrungen respektieren
+- Konstruktives Feedback geben und würdevoll annehmen
+- Verantwortung übernehmen, sich bei Betroffenen für Fehler entschuldigen und aus
+  Erfahrungen lernen
+- Sich auf das konzentrieren, was nicht nur für uns als Einzelpersonen, sondern
+  für die gesamte Community am besten ist
+
+Beispiele für inakzeptables Verhalten:
+
+- Die Verwendung sexualisierter Sprache oder Bilder sowie unerwünschte sexuelle
+  Aufmerksamkeit oder Annäherungsversuche
+- Beleidigende oder herabwürdigende Kommentare, Trolling sowie persönliche oder
+  politische Angriffe
+- Öffentliche oder private Belästigung
+- Das Veröffentlichen privater Informationen anderer ohne deren ausdrückliche
+  Erlaubnis (z.B. physische oder E-Mail-Adresse)
+- Anderes Verhalten, das in einem beruflichen Umfeld vernünftigerweise als
+  unangemessen betrachtet werden kann
+
+## Durchsetzungsverantwortung
+
+Die Verantwortlichen der Community sind dafür zuständig, unsere Standards für
+akzeptables Verhalten zu klären und durchzusetzen. Sie ergreifen angemessene und
+faire Korrekturmaßnahmen als Reaktion auf jedes Verhalten, das sie als
+unangemessen, bedrohlich, beleidigend oder schädlich erachten.
+
+Die Verantwortlichen der Community haben das Recht und die Pflicht, Kommentare,
+Commits, Code, Wiki-Bearbeitungen, Issues und andere Beiträge zu entfernen, zu
+bearbeiten oder abzulehnen, die nicht mit diesem Verhaltenskodex vereinbar sind,
+und werden die Gründe für ihre Moderationsentscheidungen bei Bedarf mitteilen.
+
+## Geltungsbereich
+
+Dieser Verhaltenskodex gilt in allen Community-Bereichen und auch dann, wenn eine
+Person die Community offiziell in öffentlichen Räumen vertritt. Beispiele für die
+Vertretung unserer Community sind die Verwendung einer offiziellen E-Mail-Adresse,
+das Posten über ein offizielles Social-Media-Konto oder das Auftreten als
+ernannte:r Vertreter:in bei einer Online- oder Offline-Veranstaltung.
+
+## Durchsetzung
+
+Fälle von missbräuchlichem, belästigendem oder anderweitig inakzeptablem Verhalten
+können den verantwortlichen Personen der Community unter
+**info@hypnose-stammtisch.de** gemeldet werden. Alle Beschwerden werden zeitnah
+und fair geprüft und untersucht.
+
+Alle Verantwortlichen der Community sind verpflichtet, die Privatsphäre und
+Sicherheit der meldenden Person zu wahren.
+
+## Durchsetzungsrichtlinien
+
+Die Verantwortlichen der Community befolgen diese Richtlinien zur Bestimmung der
+Konsequenzen für Handlungen, die sie als Verstoß gegen diesen Verhaltenskodex
+ansehen:
+
+### 1. Korrektur
+
+**Auswirkung in der Community**: Verwendung unangemessener Sprache oder anderes
+Verhalten, das als unprofessionell oder unwillkommen gilt.
+
+**Konsequenz**: Eine private, schriftliche Verwarnung durch die Verantwortlichen
+mit Klarstellung der Art des Verstoßes und einer Erklärung, warum das Verhalten
+unangemessen war. Eine öffentliche Entschuldigung kann angefordert werden.
+
+### 2. Verwarnung
+
+**Auswirkung in der Community**: Ein Verstoß durch einen einzelnen Vorfall oder
+eine Reihe von Handlungen.
+
+**Konsequenz**: Eine Verwarnung mit Konsequenzen bei fortgesetztem Verhalten.
+Keine Interaktion mit den beteiligten Personen, einschließlich unaufgeforderter
+Interaktion mit denjenigen, die den Verhaltenskodex durchsetzen, für einen
+festgelegten Zeitraum. Ein Verstoß gegen diese Bedingungen kann zu einem
+befristeten oder dauerhaften Ausschluss führen.
+
+### 3. Befristeter Ausschluss
+
+**Auswirkung in der Community**: Ein schwerwiegender Verstoß gegen die
+Community-Standards, einschließlich anhaltend unangemessenen Verhaltens.
+
+**Konsequenz**: Ein befristeter Ausschluss von jeglicher Art der Interaktion oder
+öffentlichen Kommunikation mit der Community für einen festgelegten Zeitraum.
+
+### 4. Dauerhafter Ausschluss
+
+**Auswirkung in der Community**: Aufzeigen eines Musters von Verstößen gegen die
+Community-Standards, anhaltend unangemessenes Verhalten, Belästigung einer Person
+oder Aggression gegenüber bzw. Herabwürdigung von Gruppen.
+
+**Konsequenz**: Ein dauerhafter Ausschluss von jeglicher Art öffentlicher
+Interaktion innerhalb der Community.
+
+## Attribution
+
+Dieser Verhaltenskodex basiert auf dem [Contributor Covenant][homepage],
+Version 2.1, verfügbar unter
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Die Richtlinien zur Durchsetzung wurden vom
+[Verhaltenskodex von Mozilla](https://github.com/mozilla/diversity) inspiriert.
+
+[homepage]: https://www.contributor-covenant.org
+
+Antworten auf häufige Fragen zu diesem Verhaltenskodex finden sich unter
+https://www.contributor-covenant.org/faq. Übersetzungen sind unter
+https://www.contributor-covenant.org/translations verfügbar.

--- a/backend/api/admin.php
+++ b/backend/api/admin.php
@@ -143,6 +143,12 @@ try {
 
   // Route events endpoints
   if (str_starts_with($path, '/events')) {
+    // Manager autocomplete (fixed path — must be matched before /events/{id})
+    if ($path === '/events/manager-search' && $method === 'GET') {
+      AdminEventsController::searchManagerCandidates();
+      return;
+    }
+
     // Series specific nested routes: /events/series/{id}/...
     if (preg_match('#^/events/series/([a-zA-Z0-9\-]+)/overrides$#', $path, $matches)) {
       $seriesId = (string)$matches[1];
@@ -187,6 +193,24 @@ try {
         \HypnoseStammtisch\Controllers\AdminEventsController::restoreSeriesInstance($seriesId);
         return;
       }
+    } elseif (preg_match('#^/events/series/([a-zA-Z0-9\-]+)/managers$#', $path, $matches)) {
+      $seriesId = (string)$matches[1];
+      if ($method === 'GET') {
+        AdminEventsController::listManagers('series', $seriesId);
+        return;
+      } elseif ($method === 'POST') {
+        AdminEventsController::addManager('series', $seriesId);
+        return;
+      } elseif ($method === 'DELETE') {
+        AdminEventsController::removeManager('series', $seriesId);
+        return;
+      }
+    } elseif (preg_match('#^/events/series/([a-zA-Z0-9\-]+)/owner$#', $path, $matches)) {
+      $seriesId = (string)$matches[1];
+      if (in_array($method, ['PUT', 'PATCH'], true)) {
+        AdminEventsController::reassignOwner('series', $seriesId);
+        return;
+      }
     }
     if ($path === '/events') {
       if ($method === 'GET') {
@@ -204,6 +228,24 @@ try {
       }
       Response::error('Method not allowed', 405);
       return;
+    } elseif (preg_match('#^/events/([a-zA-Z0-9\-]+)/managers$#', $path, $matches)) {
+      $id = (string)$matches[1];
+      if ($method === 'GET') {
+        AdminEventsController::listManagers('event', $id);
+        return;
+      } elseif ($method === 'POST') {
+        AdminEventsController::addManager('event', $id);
+        return;
+      } elseif ($method === 'DELETE') {
+        AdminEventsController::removeManager('event', $id);
+        return;
+      }
+    } elseif (preg_match('#^/events/([a-zA-Z0-9\-]+)/owner$#', $path, $matches)) {
+      $id = (string)$matches[1];
+      if (in_array($method, ['PUT', 'PATCH'], true)) {
+        AdminEventsController::reassignOwner('event', $id);
+        return;
+      }
     } elseif (preg_match('#^/events/([a-zA-Z0-9\-]+)$#', $path, $matches)) {
       $id = (string)$matches[1];
       if ($method === 'PUT') {

--- a/backend/api/admin.php
+++ b/backend/api/admin.php
@@ -196,6 +196,14 @@ try {
         AdminEventsController::create();
         return;
       }
+    } elseif (preg_match('#^/events/([a-zA-Z0-9\-]+)/status$#', $path, $matches)) {
+      $id = (string)$matches[1];
+      if ($method === 'PATCH') {
+        AdminEventsController::patchStatus($id);
+        return;
+      }
+      Response::error('Method not allowed', 405);
+      return;
     } elseif (preg_match('#^/events/([a-zA-Z0-9\-]+)$#', $path, $matches)) {
       $id = (string)$matches[1];
       if ($method === 'PUT') {

--- a/backend/migrations/010_add_event_end_datetime_index.sql
+++ b/backend/migrations/010_add_event_end_datetime_index.sql
@@ -1,0 +1,5 @@
+-- Migration 010: Add index on events.end_datetime
+-- Needed after switching upcoming/featured filters from start_datetime to end_datetime
+-- to prevent full table scans on those queries.
+
+ALTER TABLE events ADD INDEX idx_end_datetime (end_datetime);

--- a/backend/migrations/011_add_event_ownership_and_sharing.sql
+++ b/backend/migrations/011_add_event_ownership_and_sharing.sql
@@ -1,0 +1,38 @@
+-- Migration 011: Event ownership + per-event manager sharing
+-- Adds a `created_by` owner column to events and event_series, a polymorphic
+-- `event_access` grant table (event OR series shared with another manager),
+-- and back-fills existing ownerless records to the primary head admin.
+-- NOTE: never add `INSERT INTO migrations` here; the runner records the version itself.
+
+-- Owner column on single events
+ALTER TABLE events
+  ADD COLUMN created_by INT NULL,
+  ADD INDEX idx_created_by (created_by),
+  ADD CONSTRAINT fk_events_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL;
+
+-- Owner column on event series
+ALTER TABLE event_series
+  ADD COLUMN created_by INT NULL,
+  ADD INDEX idx_series_created_by (created_by),
+  ADD CONSTRAINT fk_event_series_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL;
+
+-- Sharing grants: a manager (user_id) is granted access to an event or series.
+-- target_id is the UUID of the events.id or event_series.id row (polymorphic, no FK).
+CREATE TABLE IF NOT EXISTS event_access (
+  id VARCHAR(36) PRIMARY KEY DEFAULT (UUID()),
+  target_type ENUM('event','series') NOT NULL,
+  target_id VARCHAR(36) NOT NULL,
+  user_id INT NOT NULL,
+  granted_by INT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_target_user (target_type, target_id, user_id),
+  INDEX idx_target (target_type, target_id),
+  INDEX idx_user_id (user_id),
+  CONSTRAINT fk_event_access_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT fk_event_access_granted_by FOREIGN KEY (granted_by) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Back-fill existing ownerless records to the primary head admin (lowest id).
+-- If no head admin exists the subquery yields NULL and the rows stay ownerless.
+UPDATE events SET created_by = (SELECT id FROM users WHERE role = 'head' ORDER BY id ASC LIMIT 1) WHERE created_by IS NULL;
+UPDATE event_series SET created_by = (SELECT id FROM users WHERE role = 'head' ORDER BY id ASC LIMIT 1) WHERE created_by IS NULL;

--- a/backend/src/Controllers/AdminEventsController.php
+++ b/backend/src/Controllers/AdminEventsController.php
@@ -30,15 +30,43 @@ class AdminEventsController
             return;
         }
 
+        $user = AdminAuth::getCurrentUser();
+        if (!AdminAuth::userHasRole($user, AdminAuth::EVENT_MANAGEMENT_ROLES)) {
+            Response::error('Insufficient permissions to view events', 403);
+            return;
+        }
+
+        // Head/admin see everything; event managers only their own + shared records.
+        $restrictToManager = !AdminAuth::userHasRole($user, AdminAuth::EVENT_FULL_ACCESS_ROLES);
+        $userId = $user['id'];
+
         try {
             // Get single events
-            $eventsSql = "SELECT e.*, NULL as series_title
+            $eventsSql = "SELECT e.*, NULL as series_title, u.username AS owner_username
                          FROM events e
-                         WHERE e.series_id IS NULL
-                         ORDER BY e.start_datetime DESC";
+                         LEFT JOIN users u ON u.id = e.created_by
+                         WHERE e.series_id IS NULL";
+            $eventParams = [];
+            if ($restrictToManager) {
+                $eventsSql .= " AND (e.created_by = ? OR e.id IN (
+                                  SELECT target_id FROM event_access
+                                  WHERE target_type = 'event' AND user_id = ?))";
+                $eventParams[] = $userId;
+                $eventParams[] = $userId;
+            }
+            $eventsSql .= " ORDER BY e.start_datetime DESC";
+
             $events = array_map(
-                fn(array $event): array => self::formatEventForAdminResponse($event),
-                Database::fetchAll($eventsSql)
+                function (array $event) use ($userId): array {
+                    $event = self::formatEventForAdminResponse($event);
+                    $event['is_owner'] = isset($event['created_by'])
+                        && $event['created_by'] !== null
+                        && (string)$event['created_by'] === (string)$userId;
+                    // Don't expose the internal owner id; is_owner + owner_username suffice.
+                    unset($event['created_by']);
+                    return $event;
+                },
+                Database::fetchAll($eventsSql, $eventParams)
             );
 
             // Get event series with aliased fields for frontend compatibility
@@ -49,12 +77,31 @@ class AdminEventsController
                          s.default_category as category,
                          s.default_max_participants as max_participants,
                          s.default_requires_registration as requires_registration,
-                         COUNT(e.id) as generated_events_count
+                         COUNT(e.id) as generated_events_count,
+                         (SELECT username FROM users WHERE users.id = s.created_by) AS owner_username
                          FROM event_series s
-                         LEFT JOIN events e ON e.series_id = s.id
-                         GROUP BY s.id
-                         ORDER BY s.start_date DESC";
-            $series = Database::fetchAll($seriesSql);
+                         LEFT JOIN events e ON e.series_id = s.id";
+            $seriesParams = [];
+            if ($restrictToManager) {
+                $seriesSql .= " WHERE (s.created_by = ? OR s.id IN (
+                                  SELECT target_id FROM event_access
+                                  WHERE target_type = 'series' AND user_id = ?))";
+                $seriesParams[] = $userId;
+                $seriesParams[] = $userId;
+            }
+            $seriesSql .= " GROUP BY s.id ORDER BY s.start_date DESC";
+
+            $series = array_map(
+                function (array $row) use ($userId): array {
+                    $row['is_owner'] = isset($row['created_by'])
+                        && $row['created_by'] !== null
+                        && (string)$row['created_by'] === (string)$userId;
+                    // Don't expose the internal owner id; is_owner + owner_username suffice.
+                    unset($row['created_by']);
+                    return $row;
+                },
+                Database::fetchAll($seriesSql, $seriesParams)
+            );
 
             // Combine and sort by creation date
             $allEvents = array_merge($events, $series);
@@ -67,6 +114,64 @@ class AdminEventsController
         } catch (Exception $e) {
             Response::error('Failed to fetch events: ' . $e->getMessage(), 500);
         }
+    }
+
+    /**
+     * Authorize the current user for a specific event/series and return the user row.
+     *
+     * Head/admin always pass. Event managers must own the target, or — when
+     * $ownerOnly is false — have been granted access via event_access. This
+     * helper emits the appropriate error response and exits when access is denied,
+     * so callers can treat a returned value as "authorized".
+     *
+     * @param 'event'|'series' $targetType
+     * @param array<string, mixed>|null $user Pre-fetched current user, to avoid a duplicate lookup.
+     * @return array<string, mixed> The authenticated user row
+     */
+    private static function requireTargetAccess(string $targetType, string $targetId, bool $ownerOnly = false, ?array $user = null): array
+    {
+        $user ??= AdminAuth::getCurrentUser();
+        if (!$user) {
+            Response::unauthorized(['message' => 'Authentication required']);
+            exit;
+        }
+
+        if (AdminAuth::userHasRole($user, AdminAuth::EVENT_FULL_ACCESS_ROLES)) {
+            return $user;
+        }
+
+        if (!AdminAuth::userHasRole($user, AdminAuth::EVENT_MANAGEMENT_ROLES)) {
+            Response::error('Insufficient permissions', 403);
+            exit;
+        }
+
+        $table = $targetType === 'series' ? 'event_series' : 'events';
+        $row = Database::fetchOne("SELECT created_by FROM {$table} WHERE id = ?", [$targetId]);
+        if (!$row) {
+            Response::notFound(['message' => 'Event not found']);
+            exit;
+        }
+
+        $isOwner = $row['created_by'] !== null && (string)$row['created_by'] === (string)$user['id'];
+        if ($isOwner) {
+            return $user;
+        }
+
+        if ($ownerOnly) {
+            Response::error('Nur der Eigentümer kann diese Aktion ausführen', 403);
+            exit;
+        }
+
+        $shared = Database::fetchOne(
+            "SELECT id FROM event_access WHERE target_type = ? AND target_id = ? AND user_id = ?",
+            [$targetType, $targetId, $user['id']]
+        );
+        if ($shared) {
+            return $user;
+        }
+
+        Response::error('Keine Berechtigung für dieses Element', 403);
+        exit;
     }
 
     /**
@@ -91,11 +196,13 @@ class AdminEventsController
         $input = json_decode(file_get_contents('php://input'), true) ?? [];
 
         $eventType = $input['event_type'] ?? 'single';
+        // getCurrentUser() returns id as a PDO string; cast for the ?int parameter (strict_types).
+        $createdBy = isset($user['id']) ? (int)$user['id'] : null;
 
         if ($eventType === 'series') {
-            self::createSeries($input);
+            self::createSeries($input, $createdBy);
         } else {
-            self::createSingleEvent($input);
+            self::createSingleEvent($input, $createdBy);
         }
     }
 
@@ -130,6 +237,10 @@ class AdminEventsController
             return;
         }
 
+        $targetType = $result['type'] === 'series' ? 'series' : 'event';
+        // Owner, granted manager, or admin/head may edit.
+        self::requireTargetAccess($targetType, $id, false, $user);
+
         if ($result['type'] === 'series') {
             self::updateSeries($id, $input);
         } else {
@@ -149,30 +260,40 @@ class AdminEventsController
             Response::error('Authentication required', 401);
             return;
         }
-        // event role has restricted delete rights
-        $isEventManager = $user['role'] === 'event_manager';
 
         if ($_SERVER['REQUEST_METHOD'] !== 'DELETE') {
             Response::error('Method not allowed', 405);
             return;
         }
 
+        // Resolve type up-front (events first, then series — avoid UNION ambiguity
+        // if the same UUID ever existed in both tables) before opening a transaction.
+        $isEvent = Database::fetchOne("SELECT id FROM events WHERE id = ?", [$id]);
+        $isSeries = !$isEvent ? Database::fetchOne("SELECT id FROM event_series WHERE id = ?", [$id]) : null;
+        if (!$isEvent && !$isSeries) {
+            Response::notFound(['message' => 'Event not found']);
+            return;
+        }
+        $type = $isSeries ? 'series' : 'event';
+
+        // Only the owner (or admin/head) may delete; granted managers cannot.
+        self::requireTargetAccess($type, $id, true, $user);
+
+        // event role has restricted delete rights (past events only)
+        $isEventManager = $user['role'] === 'event_manager';
+
         try {
             Database::beginTransaction();
 
-            // Check if it's a series or single event
-            $checkSql = "SELECT 'event' as type FROM events WHERE id = ?
-                         UNION
-                         SELECT 'series' as type FROM event_series WHERE id = ?";
-            $result = Database::fetchOne($checkSql, [$id, $id]);
-
-            if (!$result) {
-                Response::notFound(['message' => 'Event not found']);
-                return;
-            }
-
-            if ($result['type'] === 'series') {
-                // Delete series and all associated events
+            if ($type === 'series') {
+                // Drop sharing grants first (events.target rows + the series itself),
+                // then the child events and the series.
+                Database::execute(
+                    "DELETE FROM event_access WHERE target_type = 'event'
+                       AND target_id IN (SELECT id FROM events WHERE series_id = ?)",
+                    [$id]
+                );
+                Database::execute("DELETE FROM event_access WHERE target_type = 'series' AND target_id = ?", [$id]);
                 Database::execute("DELETE FROM events WHERE series_id = ?", [$id]);
                 Database::execute("DELETE FROM event_series WHERE id = ?", [$id]);
                 $message = 'Event series deleted successfully';
@@ -181,16 +302,19 @@ class AdminEventsController
                     // Check if event already ended (end_datetime < now UTC)
                     $event = Database::fetchOne("SELECT end_datetime FROM events WHERE id = ?", [$id]);
                     if (!$event) {
+                        Database::rollback();
                         Response::notFound(['message' => 'Event not found']);
                         return;
                     }
                     $now = new \DateTime('now', new \DateTimeZone('UTC'));
                     $end = new \DateTime($event['end_datetime'], new \DateTimeZone('UTC'));
                     if ($end > $now) {
+                        Database::rollback();
                         Response::error('Event-Manager can only delete past events', 403);
                         return;
                     }
                 }
+                Database::execute("DELETE FROM event_access WHERE target_type = 'event' AND target_id = ?", [$id]);
                 Database::execute("DELETE FROM events WHERE id = ?", [$id]);
                 $message = 'Event deleted successfully';
             }
@@ -248,6 +372,9 @@ class AdminEventsController
                 return;
             }
 
+            // Owner, granted manager, or admin/head may change status.
+            self::requireTargetAccess($isSeries ? 'series' : 'event', $id, false, $user);
+
             if ($isSeries) {
                 if (!in_array($status, $allowedSeriesStatuses, true)) {
                     Response::error('Series status must be one of: ' . implode(', ', $allowedSeriesStatuses), 400);
@@ -275,7 +402,7 @@ class AdminEventsController
     /**
      * Create single event
      */
-    private static function createSingleEvent(array $input): void
+    private static function createSingleEvent(array $input, ?int $createdBy = null): void
     {
         error_log('[createSingleEvent] Input received: ' . json_encode($input));
 
@@ -325,8 +452,8 @@ class AdminEventsController
                 title, slug, description, content, start_datetime, end_datetime, timezone,
                 location_type, location_name, location_address, location_url,
                 category, difficulty_level, max_participants, status, is_featured,
-                requires_registration, organizer_name, organizer_email, tags
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                requires_registration, organizer_name, organizer_email, tags, created_by
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
             $eventId = Database::insert($sql, [
                 $input['title'],
@@ -348,7 +475,8 @@ class AdminEventsController
                 isset($input['requires_registration']) ? (int)$input['requires_registration'] : 1,
                 $input['organizer_name'] ?? null,
                 $input['organizer_email'] ?? null,
-                isset($input['tags']) ? json_encode($input['tags']) : null
+                isset($input['tags']) ? json_encode($input['tags']) : null,
+                $createdBy
             ]);
 
             Response::success(['id' => $eventId], 'Event created successfully');
@@ -385,7 +513,7 @@ class AdminEventsController
     /**
      * Create event series
      */
-    private static function createSeries(array $input): void
+    private static function createSeries(array $input, ?int $createdBy = null): void
     {
         $validator = new Validator($input);
         $validator->required(['title', 'rrule', 'start_date'])
@@ -450,8 +578,8 @@ class AdminEventsController
         title, slug, description, rrule, start_date, end_date, start_time, end_time, exdates,
         default_location_type, default_location_name,
         default_location_address, default_category, default_max_participants,
-        default_requires_registration, status, tags
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        default_requires_registration, status, tags, created_by
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
             try {
                 $seriesId = Database::insert($sql, [
@@ -471,7 +599,8 @@ class AdminEventsController
                     $input['default_max_participants'] ?? null,
                     $input['default_requires_registration'] ?? true,
                     $input['status'] ?? 'draft',
-                    $tagsJson
+                    $tagsJson,
+                    $createdBy
                 ]);
             } catch (\Exception $inner) {
                 $innerMsg = $inner->getMessage();
@@ -804,16 +933,14 @@ class AdminEventsController
     {
         AdminAuth::requireAuth();
         AdminAuth::requireCSRF();
-        $user = AdminAuth::getCurrentUser();
-        if (!AdminAuth::userHasRole($user, AdminAuth::EVENT_MANAGEMENT_ROLES)) {
-            Response::error('Insufficient permissions', 403);
-            return;
-        }
 
         if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
             Response::error('Method not allowed', 405);
             return;
         }
+
+        $user = self::requireTargetAccess('series', $seriesId);
+        $createdBy = $user['id'] ?? null;
 
         $input = json_decode(file_get_contents('php://input'), true) ?? [];
         $validator = new Validator($input);
@@ -857,8 +984,8 @@ class AdminEventsController
         title, slug, description, content, start_datetime, end_datetime, timezone,
         location_type, location_name, location_address, location_url, category, difficulty_level,
         max_participants, status, is_featured, requires_registration, organizer_name, organizer_email,
-        tags, series_id, instance_date, parent_event_id, override_type
-      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)';
+        tags, series_id, instance_date, parent_event_id, override_type, created_by
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)';
 
             $title = $input['title'] ?? $series['title'];
             $slug = self::generateSlug($title);
@@ -886,7 +1013,8 @@ class AdminEventsController
                 $seriesId,
                 $instanceDate,
                 null,
-                'changed'
+                'changed',
+                $createdBy
             ]);
 
             Response::success(['id' => $eventId], 'Series override created');
@@ -905,6 +1033,7 @@ class AdminEventsController
             Response::error('Method not allowed', 405);
             return;
         }
+        self::requireTargetAccess('series', $seriesId);
         try {
             $rows = array_map(
                 fn(array $event): array => self::formatEventForAdminResponse($event),
@@ -927,6 +1056,7 @@ class AdminEventsController
             Response::error('Method not allowed', 405);
             return;
         }
+        self::requireTargetAccess('series', $seriesId);
         try {
             $row = Database::fetchOne('SELECT id FROM events WHERE id = ? AND series_id = ?', [$overrideId, $seriesId]);
             if (!$row) {
@@ -951,6 +1081,7 @@ class AdminEventsController
             Response::error('Method not allowed', 405);
             return;
         }
+        self::requireTargetAccess('series', $seriesId);
         $input = json_decode(file_get_contents('php://input'), true) ?? [];
         if (empty($input['date'])) {
             Response::error('date required', 400);
@@ -985,6 +1116,7 @@ class AdminEventsController
             Response::error('Method not allowed', 405);
             return;
         }
+        self::requireTargetAccess('series', $seriesId);
         $date = $_GET['date'] ?? null;
         if (!$date) {
             Response::error('date query param required', 400);
@@ -1015,6 +1147,7 @@ class AdminEventsController
             Response::error('Method not allowed', 405);
             return;
         }
+        self::requireTargetAccess('series', $seriesId);
         try {
             $series = Database::fetchOne('SELECT exdates FROM event_series WHERE id = ?', [$seriesId]);
             if (!$series) {
@@ -1041,6 +1174,8 @@ class AdminEventsController
             Response::error('Method not allowed', 405);
             return;
         }
+
+        self::requireTargetAccess('series', $seriesId);
 
         $limit = isset($_GET['limit']) ? min((int) $_GET['limit'], 52) : 10;
 
@@ -1178,6 +1313,8 @@ class AdminEventsController
             Response::error('Method not allowed', 405);
             return;
         }
+        $user = self::requireTargetAccess('series', $seriesId);
+        $createdBy = $user['id'] ?? null;
         $input = json_decode(file_get_contents('php://input'), true) ?? [];
         if (empty($input['instance_date'])) {
             Response::error('instance_date required', 400);
@@ -1218,7 +1355,7 @@ class AdminEventsController
             $tz = self::DEFAULT_EVENT_TIMEZONE;
             $startUTC = self::convertToUTC($instanceDate . ' ' . $series['start_time'], $tz);
             $endUTC = self::convertToUTC($instanceDate . ' ' . $series['end_time'], $tz);
-            $insertSql = 'INSERT INTO events (title, slug, start_datetime, end_datetime, timezone, category, status, tags, series_id, instance_date, parent_event_id, override_type, cancellation_reason) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)';
+            $insertSql = 'INSERT INTO events (title, slug, start_datetime, end_datetime, timezone, category, status, tags, series_id, instance_date, parent_event_id, override_type, cancellation_reason, created_by) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)';
             $title = $series['title'] . ' (abgesagt)';
             $slug = self::generateSlug($title . '-' . $instanceDate);
             $id = Database::insert($insertSql, [
@@ -1234,7 +1371,8 @@ class AdminEventsController
                 $instanceDate,
                 null,
                 'cancelled',
-                $input['reason'] ?? null
+                $input['reason'] ?? null,
+                $createdBy
             ]);
             Response::success(['id' => $id], 'Instance cancelled');
         } catch (\Exception $e) {
@@ -1254,6 +1392,7 @@ class AdminEventsController
             Response::error('Method not allowed', 405);
             return;
         }
+        self::requireTargetAccess('series', $seriesId);
         $instanceDate = $_GET['instance_date'] ?? null;
         if (!$instanceDate) {
             Response::error('instance_date query param required', 400);
@@ -1275,6 +1414,260 @@ class AdminEventsController
             Response::success(null, 'No cancellation to remove');
         } catch (\Exception $e) {
             Response::error('Failed to restore instance: ' . $e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * List the managers an event/series is shared with (owner + grantees).
+     * Only the owner (or admin/head) may view the share list.
+     * Returns usernames only — never any personal detail of another manager.
+     *
+     * GET /events/{id}/managers  |  GET /events/series/{id}/managers
+     *
+     * @param 'event'|'series' $targetType
+     */
+    public static function listManagers(string $targetType, string $id): void
+    {
+        AdminAuth::requireAuth();
+        if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+            Response::error('Method not allowed', 405);
+            return;
+        }
+        self::requireTargetAccess($targetType, $id, true);
+
+        try {
+            $table = $targetType === 'series' ? 'event_series' : 'events';
+            $target = Database::fetchOne(
+                "SELECT u.username AS owner_username
+                 FROM {$table} t LEFT JOIN users u ON u.id = t.created_by
+                 WHERE t.id = ?",
+                [$id]
+            );
+            $managers = Database::fetchAll(
+                "SELECT u.username
+                 FROM event_access ea
+                 JOIN users u ON u.id = ea.user_id
+                 WHERE ea.target_type = ? AND ea.target_id = ?
+                 ORDER BY u.username ASC",
+                [$targetType, $id]
+            );
+
+            Response::success([
+                'owner_username' => $target['owner_username'] ?? null,
+                'managers' => array_map(static fn(array $m): array => ['username' => $m['username']], $managers),
+            ]);
+        } catch (\Exception $e) {
+            Response::error('Failed to list managers: ' . $e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * Grant another event manager access to an event/series by username.
+     * Only the owner (or admin/head) may grant. Access can only be granted to an
+     * active user whose role is event_manager. No personal details are returned or
+     * required — just the username.
+     *
+     * POST /events/{id}/managers  body { username }
+     *
+     * @param 'event'|'series' $targetType
+     */
+    public static function addManager(string $targetType, string $id): void
+    {
+        AdminAuth::requireAuth();
+        AdminAuth::requireCSRF();
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            Response::error('Method not allowed', 405);
+            return;
+        }
+        $actor = self::requireTargetAccess($targetType, $id, true);
+
+        $input = json_decode(file_get_contents('php://input'), true) ?? [];
+        $username = isset($input['username']) ? trim((string)$input['username']) : '';
+        if ($username === '') {
+            Response::error('username erforderlich', 400);
+            return;
+        }
+
+        try {
+            // Only active event managers may be granted access.
+            $grantee = Database::fetchOne(
+                "SELECT id, username FROM users WHERE username = ? AND is_active = 1 AND role = 'event_manager'",
+                [$username]
+            );
+            if (!$grantee) {
+                Response::error('Kein aktiver Event-Manager mit diesem Benutzernamen gefunden', 404);
+                return;
+            }
+
+            // Owner already has full access — granting to them is a no-op.
+            $table = $targetType === 'series' ? 'event_series' : 'events';
+            $target = Database::fetchOne("SELECT created_by FROM {$table} WHERE id = ?", [$id]);
+            if ($target && (string)$target['created_by'] === (string)$grantee['id']) {
+                Response::error('Dieser Benutzer ist bereits der Eigentümer', 400);
+                return;
+            }
+
+            Database::execute(
+                "INSERT INTO event_access (target_type, target_id, user_id, granted_by)
+                 VALUES (?, ?, ?, ?)
+                 ON DUPLICATE KEY UPDATE granted_by = ?",
+                [$targetType, $id, $grantee['id'], $actor['id'], $actor['id']]
+            );
+
+            Response::success(['username' => $grantee['username']], 'Zugriff gewährt');
+        } catch (\Exception $e) {
+            Response::error('Failed to add manager: ' . $e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * Revoke a previously granted manager's access by username.
+     * Only the owner (or admin/head) may revoke.
+     *
+     * DELETE /events/{id}/managers?username=...
+     *
+     * @param 'event'|'series' $targetType
+     */
+    public static function removeManager(string $targetType, string $id): void
+    {
+        AdminAuth::requireAuth();
+        AdminAuth::requireCSRF();
+        if ($_SERVER['REQUEST_METHOD'] !== 'DELETE') {
+            Response::error('Method not allowed', 405);
+            return;
+        }
+        self::requireTargetAccess($targetType, $id, true);
+
+        $username = isset($_GET['username']) ? trim((string)$_GET['username']) : '';
+        if ($username === '') {
+            Response::error('username Query-Parameter erforderlich', 400);
+            return;
+        }
+
+        try {
+            $grantee = Database::fetchOne("SELECT id FROM users WHERE username = ?", [$username]);
+            if (!$grantee) {
+                Response::error('Benutzer nicht gefunden', 404);
+                return;
+            }
+            Database::execute(
+                "DELETE FROM event_access WHERE target_type = ? AND target_id = ? AND user_id = ?",
+                [$targetType, $id, $grantee['id']]
+            );
+            Response::success(null, 'Zugriff entzogen');
+        } catch (\Exception $e) {
+            Response::error('Failed to remove manager: ' . $e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * Autocomplete helper for the share dialog: returns matching event-manager
+     * usernames only. Deliberately exposes no email, id, or other personal detail.
+     *
+     * GET /events/manager-search?q=...
+     */
+    public static function searchManagerCandidates(): void
+    {
+        AdminAuth::requireAuth();
+        if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+            Response::error('Method not allowed', 405);
+            return;
+        }
+        $user = AdminAuth::getCurrentUser();
+        if (!AdminAuth::userHasRole($user, AdminAuth::EVENT_MANAGEMENT_ROLES)) {
+            Response::error('Insufficient permissions', 403);
+            return;
+        }
+
+        $q = isset($_GET['q']) ? trim((string)$_GET['q']) : '';
+        if (mb_strlen($q) < 2) {
+            Response::success(['usernames' => []]);
+            return;
+        }
+
+        try {
+            // Escape LIKE metacharacters so a query containing % or _ can't widen the match.
+            $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $q);
+            $like = '%' . $escaped . '%';
+            $rows = Database::fetchAll(
+                "SELECT username FROM users
+                 WHERE is_active = 1 AND role = 'event_manager' AND username LIKE ? ESCAPE '\\'
+                 ORDER BY username ASC LIMIT 10",
+                [$like]
+            );
+            Response::success(['usernames' => array_column($rows, 'username')]);
+        } catch (\Exception $e) {
+            Response::error('Failed to search managers: ' . $e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * Reassign the owner of an event/series to another event-capable user.
+     * Head-admin only. The new owner must be an active user whose role can manage
+     * events (head, admin, or event_manager).
+     *
+     * PUT /events/{id}/owner  |  PUT /events/series/{id}/owner   body { username }
+     *
+     * @param 'event'|'series' $targetType
+     */
+    public static function reassignOwner(string $targetType, string $id): void
+    {
+        AdminAuth::requireAuth();
+        AdminAuth::requireCSRF();
+        if (!in_array($_SERVER['REQUEST_METHOD'], ['PUT', 'PATCH'], true)) {
+            Response::error('Method not allowed', 405);
+            return;
+        }
+
+        $user = AdminAuth::getCurrentUser();
+        if (!AdminAuth::userHasRole($user, AdminAuth::HEAD_ADMIN_ROLES)) {
+            Response::error('Nur der Head-Admin kann Veranstaltungen neu zuweisen', 403);
+            return;
+        }
+
+        $table = $targetType === 'series' ? 'event_series' : 'events';
+        $target = Database::fetchOne("SELECT id FROM {$table} WHERE id = ?", [$id]);
+        if (!$target) {
+            Response::notFound(['message' => 'Event not found']);
+            return;
+        }
+
+        $input = json_decode(file_get_contents('php://input'), true) ?? [];
+        $username = isset($input['username']) ? trim((string)$input['username']) : '';
+        if ($username === '') {
+            Response::error('username erforderlich', 400);
+            return;
+        }
+
+        try {
+            $newOwner = Database::fetchOne(
+                "SELECT id, username, role FROM users WHERE username = ? AND is_active = 1",
+                [$username]
+            );
+            if (!$newOwner) {
+                Response::error('Kein aktiver Benutzer mit diesem Benutzernamen gefunden', 404);
+                return;
+            }
+            if (!in_array($newOwner['role'], AdminAuth::EVENT_MANAGEMENT_ROLES, true)) {
+                Response::error('Der neue Besitzer muss Veranstaltungen verwalten dürfen', 400);
+                return;
+            }
+
+            Database::beginTransaction();
+            Database::execute("UPDATE {$table} SET created_by = ? WHERE id = ?", [$newOwner['id'], $id]);
+            // A grant to the new owner is now redundant — they own the record.
+            Database::execute(
+                "DELETE FROM event_access WHERE target_type = ? AND target_id = ? AND user_id = ?",
+                [$targetType, $id, $newOwner['id']]
+            );
+            Database::commit();
+
+            Response::success(['owner_username' => $newOwner['username']], 'Besitzer neu zugewiesen');
+        } catch (\Exception $e) {
+            if (Database::inTransaction()) {
+                Database::rollback();
+            }
+            Response::error('Failed to reassign owner: ' . $e->getMessage(), 500);
         }
     }
 }

--- a/backend/src/Controllers/AdminEventsController.php
+++ b/backend/src/Controllers/AdminEventsController.php
@@ -204,6 +204,75 @@ class AdminEventsController
     }
 
     /**
+     * Update only the status of an event or series (PATCH)
+     */
+    public static function patchStatus(string $id): void
+    {
+        AdminAuth::requireAuth();
+        AdminAuth::requireCSRF();
+        $user = AdminAuth::getCurrentUser();
+        if (!AdminAuth::userHasRole($user, AdminAuth::EVENT_MANAGEMENT_ROLES)) {
+            Response::error('Insufficient permissions', 403);
+            return;
+        }
+
+        if ($_SERVER['REQUEST_METHOD'] !== 'PATCH') {
+            Response::error('Method not allowed', 405);
+            return;
+        }
+
+        $decoded = json_decode(file_get_contents('php://input'), true);
+        if (!is_array($decoded)) {
+            Response::error('Invalid JSON body', 400);
+            return;
+        }
+        $input = $decoded;
+        $status = $input['status'] ?? null;
+
+        $allowedEventStatuses = ['draft', 'published', 'cancelled', 'completed'];
+        $allowedSeriesStatuses = ['draft', 'published', 'cancelled'];
+
+        if (!in_array($status, $allowedEventStatuses, true)) {
+            Response::error('Invalid status. Must be one of: ' . implode(', ', $allowedEventStatuses), 400);
+            return;
+        }
+
+        try {
+            // Check events first, then series — sequential to avoid UNION
+            // returning an arbitrary row if the same UUID existed in both tables.
+            $isEvent = Database::fetchOne("SELECT id FROM events WHERE id = ?", [$id]);
+            $isSeries = !$isEvent && Database::fetchOne("SELECT id FROM event_series WHERE id = ?", [$id]);
+
+            if (!$isEvent && !$isSeries) {
+                Response::notFound(['message' => 'Event or series not found']);
+                return;
+            }
+
+            if ($isSeries) {
+                if (!in_array($status, $allowedSeriesStatuses, true)) {
+                    Response::error('Series status must be one of: ' . implode(', ', $allowedSeriesStatuses), 400);
+                    return;
+                }
+                Database::execute(
+                    "UPDATE event_series SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    [$status, $id]
+                );
+            } else {
+                Database::execute(
+                    "UPDATE events SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    [$status, $id]
+                );
+            }
+
+            Response::success(['status' => $status], 'Status updated successfully');
+        } catch (Exception $e) {
+            error_log('[patchStatus] Exception: ' . $e->getMessage());
+            $debug = \HypnoseStammtisch\Config\Config::get('app.debug', false);
+            Response::error($debug ? 'Failed to update status: ' . $e->getMessage() : 'Failed to update status', 500);
+        }
+    }
+
+    /**
      * Create single event
      */
     private static function createSingleEvent(array $input): void

--- a/backend/src/Controllers/EventsController.php
+++ b/backend/src/Controllers/EventsController.php
@@ -24,6 +24,12 @@ class EventsController
     private const PUBLIC_OVERRIDE_STATUSES = ['published', 'cancelled'];
 
     /**
+     * How far ahead the upcoming endpoint expands recurring series/events. Chosen
+     * generously so even sparse (e.g. monthly) series can fill the requested limit.
+     */
+    private const UPCOMING_EXPANSION_MONTHS = 24;
+
+    /**
      * Helper function to convert event to array (handles mock objects)
      */
     private function eventToArray($event): array
@@ -245,8 +251,25 @@ class EventsController
             $limit = (int)($_GET['limit'] ?? 5);
             $limit = min(max($limit, 1), 20); // Between 1 and 20
 
-            $events = Event::getUpcoming($limit);
-            $eventsData = array_map(fn($event) => $this->eventToArray($event), $events);
+            $now = Carbon::now(self::DEFAULT_TIMEZONE);
+
+            // Expand legacy recurring events and series (event_series) into concrete
+            // instances so recurring offers whose base/start date lies in the past
+            // still contribute their upcoming occurrences. Querying the events table
+            // alone (Event::getUpcoming) misses dynamically generated series instances
+            // entirely and drops recurring rows once their original date has passed.
+            //
+            // The lower bound is widened by a day so the timezone offset between the
+            // UTC-stored events table and the local wall-clock reference cannot drop a
+            // near-term event; the precise cut-off is applied afterwards on the
+            // already timezone-normalized instances.
+            $filters = [
+                'from_date' => $now->copy()->subDay()->startOfDay()->toDateTimeString(),
+                'to_date' => $now->copy()->addMonths(self::UPCOMING_EXPANSION_MONTHS)->toDateTimeString(),
+            ];
+
+            $expanded = $this->getExpandedEvents($filters);
+            $eventsData = $this->selectUpcomingFromExpanded($expanded, $now->getTimestamp(), $limit);
 
             Response::json([
                 'success' => true,
@@ -263,6 +286,50 @@ class EventsController
                 'error' => 'Failed to fetch upcoming events'
             ], 500);
         }
+    }
+
+    /**
+     * Reduce an expanded event list to the public "upcoming" view: drop events that
+     * have already ended or are cancelled, order by start, and cap to $limit.
+     *
+     * @param array<int, array<string, mixed>> $expanded
+     * @param int $referenceTimestamp Unix timestamp used as the "now" boundary
+     * @return array<int, array<string, mixed>>
+     */
+    private function selectUpcomingFromExpanded(array $expanded, int $referenceTimestamp, int $limit): array
+    {
+        $upcoming = array_filter($expanded, function (array $event) use ($referenceTimestamp): bool {
+            if ($this->isCancelledEvent($event)) {
+                return false;
+            }
+
+            // Treat an event as upcoming while it has not ended yet (mirrors the
+            // previous end_datetime > now semantics so currently running events stay).
+            $end = $event['end_datetime'] ?? ($event['start_datetime'] ?? null);
+            if (!is_string($end) || $end === '') {
+                return false;
+            }
+
+            $endTimestamp = strtotime($end);
+
+            return $endTimestamp !== false && $endTimestamp > $referenceTimestamp;
+        });
+
+        usort(
+            $upcoming,
+            static fn (array $a, array $b): int => strtotime($a['start_datetime']) <=> strtotime($b['start_datetime'])
+        );
+
+        return array_slice(array_values($upcoming), 0, max($limit, 0));
+    }
+
+    /**
+     * @param array<string, mixed> $event
+     */
+    private function isCancelledEvent(array $event): bool
+    {
+        return ($event['override_type'] ?? null) === 'cancelled'
+            || ($event['status'] ?? null) === 'cancelled';
     }
 
     /**

--- a/backend/src/Controllers/SetupController.php
+++ b/backend/src/Controllers/SetupController.php
@@ -37,7 +37,7 @@ class SetupController
     public function __construct()
     {
         $this->isProduction = ($_ENV['APP_ENV'] ?? 'production') === 'production';
-        $this->isForced = $this->getParam('force', false);
+        $this->isForced = filter_var($this->getParam('force', false), FILTER_VALIDATE_BOOLEAN);
     }
 
     /**

--- a/backend/src/Middleware/AdminAuth.php
+++ b/backend/src/Middleware/AdminAuth.php
@@ -19,6 +19,8 @@ class AdminAuth
     public const MESSAGE_MANAGEMENT_ROLES = ['head', 'admin', 'moderator'];
     public const EVENT_MANAGEMENT_ROLES = ['head', 'admin', 'event_manager'];
     public const EVENT_MANAGER_ONLY_ROLES = ['event_manager'];
+    /** Roles that may see and edit every event regardless of ownership/sharing. */
+    public const EVENT_FULL_ACCESS_ROLES = ['head', 'admin'];
 
     /**
      * Start secure session if not already started

--- a/backend/src/Models/Event.php
+++ b/backend/src/Models/Event.php
@@ -121,7 +121,7 @@ class Event
         try {
             $sql = "SELECT * FROM events
                     WHERE status = 'published'
-                    AND start_datetime > NOW()
+                    AND end_datetime > UTC_TIMESTAMP()
                     ORDER BY start_datetime ASC
                     LIMIT ?";
 
@@ -145,7 +145,7 @@ class Event
             $sql = "SELECT * FROM events
                     WHERE status = 'published'
                     AND is_featured = 1
-                    AND start_datetime > NOW()
+                    AND end_datetime > UTC_TIMESTAMP()
                     ORDER BY start_datetime ASC
                     LIMIT ?";
 

--- a/backend/src/Models/Event.php
+++ b/backend/src/Models/Event.php
@@ -55,7 +55,8 @@ class Event
         public ?string $createdAt = null,
         public ?string $updatedAt = null,
         public readonly ?string $seriesId = null,
-        public readonly ?string $instanceDate = null
+        public readonly ?string $instanceDate = null,
+        public ?int $createdBy = null
     ) {}
 
     /**
@@ -377,7 +378,8 @@ class Event
             createdAt: $data['created_at'] ?? null,
             updatedAt: $data['updated_at'] ?? null,
             seriesId: $data['series_id'] ?? null,
-            instanceDate: $data['instance_date'] ?? null
+            instanceDate: $data['instance_date'] ?? null,
+            createdBy: isset($data['created_by']) ? (int)$data['created_by'] : null
         );
     }
 
@@ -428,6 +430,9 @@ class Event
             'updated_at' => $this->updatedAt,
             'series_id' => $this->seriesId,
             'instance_date' => $this->instanceDate
+            // created_by is intentionally omitted: it is an internal owner id and
+            // must not leak through the public events API. Admin ownership logic
+            // works off raw SQL rows, not this model.
         ];
     }
 

--- a/backend/tests/Unit/Controllers/EventsControllerUpcomingTest.php
+++ b/backend/tests/Unit/Controllers/EventsControllerUpcomingTest.php
@@ -1,0 +1,413 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HypnoseStammtisch\Tests\Unit\Controllers;
+
+use HypnoseStammtisch\Controllers\EventsController;
+use HypnoseStammtisch\Database\Database;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Regression coverage for the upcoming-events endpoint.
+ *
+ * The homepage "Kommende Veranstaltungen" widget previously read the events table
+ * directly (Event::getUpcoming), so recurring series whose start/base date lies in
+ * the past contributed no upcoming occurrences at all. upcoming() now expands
+ * series + legacy recurring events and keeps only the ones that have not ended.
+ */
+class EventsControllerUpcomingTest extends TestCase
+{
+    private EventsController $controller;
+    private ReflectionMethod $getExpandedEventsMethod;
+    private ReflectionMethod $selectUpcomingMethod;
+    private PDO $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Mirror production (backend/api/index.php) so wall-clock comparisons are
+        // deterministic regardless of the host timezone.
+        date_default_timezone_set('Europe/Berlin');
+
+        $this->controller = new EventsController();
+
+        $this->getExpandedEventsMethod = new ReflectionMethod(EventsController::class, 'getExpandedEvents');
+        $this->getExpandedEventsMethod->setAccessible(true);
+        $this->selectUpcomingMethod = new ReflectionMethod(EventsController::class, 'selectUpcomingFromExpanded');
+        $this->selectUpcomingMethod->setAccessible(true);
+
+        $this->connection = new PDO('sqlite::memory:');
+        $this->connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        $dbRef = new ReflectionClass(Database::class);
+        $dbProp = $dbRef->getProperty('connection');
+        $dbProp->setValue(null, $this->connection);
+
+        $this->createSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        $dbRef = new ReflectionClass(Database::class);
+        $dbProp = $dbRef->getProperty('connection');
+        $dbProp->setValue(null, null);
+
+        parent::tearDown();
+    }
+
+    public function testSelectUpcomingDropsEndedAndCancelledThenSortsAndLimits(): void
+    {
+        $reference = strtotime('2026-06-11 12:00:00');
+
+        $expanded = [
+            ['id' => 'ended', 'start_datetime' => '2026-06-10 19:00:00', 'end_datetime' => '2026-06-10 21:00:00'],
+            ['id' => 'ongoing', 'start_datetime' => '2026-06-11 11:00:00', 'end_datetime' => '2026-06-11 13:00:00'],
+            ['id' => 'soon', 'start_datetime' => '2026-06-12 19:00:00', 'end_datetime' => '2026-06-12 21:00:00'],
+            ['id' => 'later', 'start_datetime' => '2026-06-20 19:00:00', 'end_datetime' => '2026-06-20 21:00:00'],
+            // Cancelled instances must never surface on the public upcoming list.
+            [
+                'id' => 'cancelled-type',
+                'start_datetime' => '2026-06-13 19:00:00',
+                'end_datetime' => '2026-06-13 21:00:00',
+                'override_type' => 'cancelled',
+            ],
+            [
+                'id' => 'cancelled-status',
+                'start_datetime' => '2026-06-14 19:00:00',
+                'end_datetime' => '2026-06-14 21:00:00',
+                'status' => 'cancelled',
+            ],
+        ];
+
+        $result = $this->selectUpcoming($expanded, $reference, 5);
+        $ids = array_column($result, 'id');
+
+        // Ongoing event (started, not yet ended) is still upcoming; ended/cancelled drop out.
+        $this->assertSame(['ongoing', 'soon', 'later'], $ids);
+    }
+
+    public function testSelectUpcomingRespectsLimit(): void
+    {
+        $reference = strtotime('2026-06-11 12:00:00');
+
+        $expanded = [
+            ['id' => 'a', 'start_datetime' => '2026-06-20 19:00:00', 'end_datetime' => '2026-06-20 21:00:00'],
+            ['id' => 'b', 'start_datetime' => '2026-06-12 19:00:00', 'end_datetime' => '2026-06-12 21:00:00'],
+            ['id' => 'c', 'start_datetime' => '2026-06-15 19:00:00', 'end_datetime' => '2026-06-15 21:00:00'],
+        ];
+
+        $result = $this->selectUpcoming($expanded, $reference, 2);
+
+        $this->assertSame(['b', 'c'], array_column($result, 'id'));
+    }
+
+    public function testPublishedSeriesWithPastStartStillYieldsUpcomingInstances(): void
+    {
+        // Series created/started in January still meets every Monday with no end date.
+        $this->insertSeries([
+            'id' => 'weekly-monday',
+            'title' => 'Wöchentlicher Stammtisch',
+            'slug' => 'woechentlicher-stammtisch',
+            'start_date' => '2026-01-05', // a Monday, well in the past
+            'start_time' => '19:00:00',
+            'end_time' => '21:00:00',
+            'rrule' => 'FREQ=WEEKLY;BYDAY=MO',
+            'status' => 'published',
+        ]);
+
+        [$expanded, $reference] = $this->expandForUpcoming('2026-06-11 12:00:00');
+        $result = $this->selectUpcoming($expanded, $reference, 6);
+
+        $this->assertNotEmpty(
+            $result,
+            'A published weekly series with a past start date must still produce upcoming instances.'
+        );
+        $this->assertCount(6, $result);
+
+        foreach ($result as $event) {
+            $this->assertSame('weekly-monday', $event['series_id'] ?? null);
+            $this->assertGreaterThan(
+                $reference,
+                strtotime($event['end_datetime']),
+                'Every returned instance must end in the future.'
+            );
+        }
+
+        // First upcoming Monday after 2026-06-11 (Thursday) is 2026-06-15.
+        $this->assertSame('2026-06-15', $result[0]['instance_date'] ?? null);
+    }
+
+    public function testLegacyRecurringEventWithPastStartStillYieldsUpcomingInstances(): void
+    {
+        // Legacy recurring event stored directly in the events table; its original
+        // datetime is in the past but the recurrence continues into the future.
+        $this->insertEvent([
+            'id' => 'legacy-weekly',
+            'title' => 'Legacy Recurring',
+            'slug' => 'legacy-recurring',
+            'start_datetime' => '2026-01-07 18:00:00',
+            'end_datetime' => '2026-01-07 20:00:00',
+            'status' => 'published',
+            'is_recurring' => 1,
+            'rrule' => 'FREQ=WEEKLY;BYDAY=WE',
+        ]);
+
+        [$expanded, $reference] = $this->expandForUpcoming('2026-06-11 12:00:00');
+        $result = $this->selectUpcoming($expanded, $reference, 4);
+
+        $this->assertCount(4, $result);
+        foreach ($result as $event) {
+            $this->assertGreaterThan($reference, strtotime($event['end_datetime']));
+        }
+    }
+
+    public function testFinishedStandaloneEventIsExcluded(): void
+    {
+        $this->insertEvent([
+            'id' => 'past-standalone',
+            'title' => 'Past Standalone',
+            'slug' => 'past-standalone',
+            'start_datetime' => '2026-06-01 19:00:00',
+            'end_datetime' => '2026-06-01 21:00:00',
+            'status' => 'published',
+        ]);
+        $this->insertEvent([
+            'id' => 'future-standalone',
+            'title' => 'Future Standalone',
+            'slug' => 'future-standalone',
+            'start_datetime' => '2026-06-20 19:00:00',
+            'end_datetime' => '2026-06-20 21:00:00',
+            'status' => 'published',
+        ]);
+
+        [$expanded, $reference] = $this->expandForUpcoming('2026-06-11 12:00:00');
+        $result = $this->selectUpcoming($expanded, $reference, 6);
+        $ids = array_column($result, 'id');
+
+        $this->assertContains('future-standalone', $ids);
+        $this->assertNotContains('past-standalone', $ids);
+    }
+
+    /**
+     * Build the expanded event list using the same filter window the upcoming()
+     * endpoint constructs, returning it alongside the reference timestamp.
+     *
+     * @return array{0: array<int, array<string, mixed>>, 1: int}
+     */
+    private function expandForUpcoming(string $nowString): array
+    {
+        $now = strtotime($nowString);
+        $filters = [
+            'from_date' => date('Y-m-d 00:00:00', strtotime('-1 day', $now)),
+            'to_date' => date('Y-m-d H:i:s', strtotime('+24 months', $now)),
+        ];
+
+        return [$this->getExpandedEvents($filters), $now];
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     * @return array<int, array<string, mixed>>
+     */
+    private function getExpandedEvents(array $filters): array
+    {
+        return $this->getExpandedEventsMethod->invoke($this->controller, $filters);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $expanded
+     * @return array<int, array<string, mixed>>
+     */
+    private function selectUpcoming(array $expanded, int $reference, int $limit): array
+    {
+        return $this->selectUpcomingMethod->invoke($this->controller, $expanded, $reference, $limit);
+    }
+
+    private function createSchema(): void
+    {
+        $this->connection->exec(
+            <<<SQL
+            CREATE TABLE events (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                slug TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                content TEXT DEFAULT '',
+                start_datetime TEXT NOT NULL,
+                end_datetime TEXT NOT NULL,
+                timezone TEXT DEFAULT 'Europe/Berlin',
+                is_recurring INTEGER DEFAULT 0,
+                rrule TEXT DEFAULT NULL,
+                recurrence_end_date TEXT DEFAULT NULL,
+                parent_event_id TEXT DEFAULT NULL,
+                override_type TEXT DEFAULT NULL,
+                cancellation_reason TEXT DEFAULT NULL,
+                location_type TEXT DEFAULT 'physical',
+                location_name TEXT DEFAULT '',
+                location_address TEXT DEFAULT '',
+                location_url TEXT DEFAULT '',
+                location_instructions TEXT DEFAULT '',
+                category TEXT DEFAULT 'stammtisch',
+                difficulty_level TEXT DEFAULT 'all',
+                max_participants INTEGER DEFAULT NULL,
+                current_participants INTEGER DEFAULT 0,
+                age_restriction INTEGER DEFAULT 18,
+                requirements TEXT DEFAULT '',
+                safety_notes TEXT DEFAULT '',
+                preparation_notes TEXT DEFAULT '',
+                status TEXT NOT NULL,
+                is_featured INTEGER DEFAULT 0,
+                requires_registration INTEGER DEFAULT 1,
+                registration_deadline TEXT DEFAULT NULL,
+                organizer_name TEXT DEFAULT '',
+                organizer_email TEXT DEFAULT '',
+                organizer_bio TEXT DEFAULT '',
+                tags TEXT DEFAULT '[]',
+                meta_description TEXT DEFAULT '',
+                image_url TEXT DEFAULT '',
+                created_at TEXT DEFAULT NULL,
+                updated_at TEXT DEFAULT NULL,
+                series_id TEXT DEFAULT NULL,
+                instance_date TEXT DEFAULT NULL
+            )
+            SQL
+        );
+
+        $this->connection->exec(
+            <<<SQL
+            CREATE TABLE event_series (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                slug TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                start_date TEXT NOT NULL,
+                end_date TEXT DEFAULT NULL,
+                start_time TEXT DEFAULT NULL,
+                end_time TEXT DEFAULT NULL,
+                rrule TEXT NOT NULL,
+                exdates TEXT DEFAULT '[]',
+                default_location_type TEXT DEFAULT 'physical',
+                default_location_name TEXT DEFAULT '',
+                default_location_address TEXT DEFAULT '',
+                default_category TEXT DEFAULT 'stammtisch',
+                default_duration_minutes INTEGER DEFAULT 120,
+                tags TEXT DEFAULT '[]',
+                status TEXT NOT NULL,
+                created_at TEXT DEFAULT NULL,
+                updated_at TEXT DEFAULT NULL
+            )
+            SQL
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $series
+     */
+    private function insertSeries(array $series): void
+    {
+        $defaults = [
+            'description' => '',
+            'end_date' => null,
+            'start_time' => '19:00:00',
+            'end_time' => '21:00:00',
+            'exdates' => '[]',
+            'default_location_type' => 'physical',
+            'default_location_name' => 'Venue',
+            'default_location_address' => 'Street 1',
+            'default_category' => 'stammtisch',
+            'default_duration_minutes' => 120,
+            'tags' => '[]',
+            'status' => 'published',
+            'created_at' => '2026-01-01 10:00:00',
+            'updated_at' => '2026-01-01 10:00:00',
+        ];
+
+        $statement = $this->connection->prepare(
+            'INSERT INTO event_series (
+                id, title, slug, description, start_date, end_date, start_time, end_time,
+                rrule, exdates, default_location_type, default_location_name, default_location_address,
+                default_category, default_duration_minutes, tags, status, created_at, updated_at
+            ) VALUES (
+                :id, :title, :slug, :description, :start_date, :end_date, :start_time, :end_time,
+                :rrule, :exdates, :default_location_type, :default_location_name, :default_location_address,
+                :default_category, :default_duration_minutes, :tags, :status, :created_at, :updated_at
+            )'
+        );
+
+        $statement->execute(array_merge($defaults, $series));
+    }
+
+    /**
+     * @param array<string, mixed> $event
+     */
+    private function insertEvent(array $event): void
+    {
+        $defaults = [
+            'description' => '',
+            'content' => '',
+            'timezone' => 'Europe/Berlin',
+            'is_recurring' => 0,
+            'rrule' => null,
+            'recurrence_end_date' => null,
+            'parent_event_id' => null,
+            'override_type' => null,
+            'cancellation_reason' => null,
+            'location_type' => 'physical',
+            'location_name' => '',
+            'location_address' => '',
+            'location_url' => '',
+            'location_instructions' => '',
+            'category' => 'stammtisch',
+            'difficulty_level' => 'all',
+            'max_participants' => null,
+            'current_participants' => 0,
+            'age_restriction' => 18,
+            'requirements' => '',
+            'safety_notes' => '',
+            'preparation_notes' => '',
+            'is_featured' => 0,
+            'requires_registration' => 1,
+            'registration_deadline' => null,
+            'organizer_name' => '',
+            'organizer_email' => '',
+            'organizer_bio' => '',
+            'tags' => '[]',
+            'meta_description' => '',
+            'image_url' => '',
+            'created_at' => '2026-01-01 10:00:00',
+            'updated_at' => '2026-01-01 10:00:00',
+            'series_id' => null,
+            'instance_date' => null,
+        ];
+
+        $statement = $this->connection->prepare(
+            'INSERT INTO events (
+                id, title, slug, description, content, start_datetime, end_datetime, timezone,
+                is_recurring, rrule, recurrence_end_date, parent_event_id, override_type,
+                cancellation_reason, location_type, location_name, location_address, location_url,
+                location_instructions, category, difficulty_level, max_participants,
+                current_participants, age_restriction, requirements, safety_notes, preparation_notes,
+                status, is_featured, requires_registration, registration_deadline, organizer_name,
+                organizer_email, organizer_bio, tags, meta_description, image_url, created_at,
+                updated_at, series_id, instance_date
+            ) VALUES (
+                :id, :title, :slug, :description, :content, :start_datetime, :end_datetime, :timezone,
+                :is_recurring, :rrule, :recurrence_end_date, :parent_event_id, :override_type,
+                :cancellation_reason, :location_type, :location_name, :location_address, :location_url,
+                :location_instructions, :category, :difficulty_level, :max_participants,
+                :current_participants, :age_restriction, :requirements, :safety_notes, :preparation_notes,
+                :status, :is_featured, :requires_registration, :registration_deadline, :organizer_name,
+                :organizer_email, :organizer_bio, :tags, :meta_description, :image_url, :created_at,
+                :updated_at, :series_id, :instance_date
+            )'
+        );
+
+        $statement->execute(array_merge($defaults, $event));
+    }
+}

--- a/src/components/admin/EventShareModal.svelte
+++ b/src/components/admin/EventShareModal.svelte
@@ -1,0 +1,330 @@
+<script lang="ts">
+  import { createEventDispatcher, onDestroy, onMount } from "svelte";
+  import { AdminAPI } from "../../stores/admin";
+  import Portal from "../ui/Portal.svelte";
+
+  // Which record is being shared and how to address it on the API.
+  export let targetType: "event" | "series" = "event";
+  export let targetId: string;
+  export let title = "";
+  // Head admin only: allow reassigning the owner.
+  export let canReassign = false;
+
+  const dispatch = createEventDispatcher();
+
+  let loading = true;
+  let error = "";
+  let ownerUsername: string | null = null;
+  let managers: { username: string }[] = [];
+
+  let usernameInput = "";
+  let adding = false;
+  let suggestions: string[] = [];
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Reassign-owner state (head admin only)
+  let reassignInput = "";
+  let reassigning = false;
+  let reassignSuggestions: string[] = [];
+  let reassignTimer: ReturnType<typeof setTimeout> | null = null;
+
+  onMount(load);
+
+  // Avoid debounce callbacks firing after the modal is destroyed.
+  onDestroy(() => {
+    if (searchTimer) clearTimeout(searchTimer);
+    if (reassignTimer) clearTimeout(reassignTimer);
+  });
+
+  async function load() {
+    loading = true;
+    error = "";
+    const res = await AdminAPI.getEventManagers(targetType, targetId);
+    if (res.success) {
+      ownerUsername = res.data?.owner_username ?? null;
+      managers = res.data?.managers ?? [];
+    } else {
+      error = res.message || "Fehler beim Laden der Freigaben";
+    }
+    loading = false;
+  }
+
+  function onInput() {
+    if (searchTimer) clearTimeout(searchTimer);
+    const q = usernameInput.trim();
+    if (q.length < 2) {
+      suggestions = [];
+      return;
+    }
+    searchTimer = setTimeout(async () => {
+      const res = await AdminAPI.searchManagerCandidates(q);
+      if (res.success) {
+        const taken = new Set(managers.map((m) => m.username));
+        suggestions = (res.data?.usernames ?? []).filter(
+          (u: string) => !taken.has(u) && u !== ownerUsername,
+        );
+      }
+    }, 200);
+  }
+
+  async function addManager(name?: string) {
+    const username = (name ?? usernameInput).trim();
+    if (!username || adding) return;
+    adding = true;
+    error = "";
+    const res = await AdminAPI.addEventManager(targetType, targetId, username);
+    if (res.success) {
+      const added = res.data?.username ?? username;
+      if (!managers.some((m) => m.username === added)) {
+        managers = [...managers, { username: added }].sort((a, b) =>
+          a.username.localeCompare(b.username),
+        );
+      }
+      usernameInput = "";
+      suggestions = [];
+    } else {
+      error = res.message || "Fehler beim Teilen";
+    }
+    adding = false;
+  }
+
+  async function removeManager(username: string) {
+    error = "";
+    const res = await AdminAPI.removeEventManager(
+      targetType,
+      targetId,
+      username,
+    );
+    if (res.success) {
+      managers = managers.filter((m) => m.username !== username);
+    } else {
+      error = res.message || "Fehler beim Entziehen des Zugriffs";
+    }
+  }
+
+  function onReassignInput() {
+    if (reassignTimer) clearTimeout(reassignTimer);
+    const q = reassignInput.trim();
+    if (q.length < 2) {
+      reassignSuggestions = [];
+      return;
+    }
+    reassignTimer = setTimeout(async () => {
+      const res = await AdminAPI.searchManagerCandidates(q);
+      if (res.success) {
+        reassignSuggestions = (res.data?.usernames ?? []).filter(
+          (u: string) => u !== ownerUsername,
+        );
+      }
+    }, 200);
+  }
+
+  async function reassignOwner(name?: string) {
+    const username = (name ?? reassignInput).trim();
+    if (!username || reassigning) return;
+    reassigning = true;
+    error = "";
+    const res = await AdminAPI.reassignEventOwner(targetType, targetId, username);
+    if (res.success) {
+      reassignInput = "";
+      reassignSuggestions = [];
+      // Owner changed → refresh owner + grantees and let the parent reload its list.
+      await load();
+      dispatch("changed");
+    } else {
+      error = res.message || "Fehler beim Neuzuweisen";
+    }
+    reassigning = false;
+  }
+
+  function close() {
+    dispatch("close");
+  }
+</script>
+
+<Portal>
+  <div
+    class="fixed inset-0 bg-gray-700/50 dark:bg-charcoal-900/80 backdrop-blur-sm overflow-y-auto h-full w-full z-[9999]"
+  >
+    <div
+      class="relative top-16 mx-auto p-6 border dark:border-charcoal-600 w-11/12 max-w-md shadow-2xl rounded-lg bg-white dark:bg-charcoal-800"
+    >
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-smoke-50">
+            Veranstaltung teilen
+          </h3>
+          {#if title}
+            <p class="text-xs text-slate-600 dark:text-smoke-400 mt-1">
+              {title}
+            </p>
+          {/if}
+        </div>
+        <button
+          type="button"
+          class="text-xs px-2 py-1 rounded border dark:border-charcoal-500 shadow-sm hover:bg-gray-100 dark:hover:bg-charcoal-600 text-gray-700 dark:text-smoke-200"
+          on:click={close}>Schließen</button
+        >
+      </div>
+
+      {#if error}
+        <div
+          class="mt-4 rounded-md border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/30 p-3 text-sm text-red-700 dark:text-red-200"
+          role="alert"
+        >
+          {error}
+        </div>
+      {/if}
+
+      {#if loading}
+        <div class="flex justify-center py-8">
+          <div
+            class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 dark:border-blue-400"
+          ></div>
+        </div>
+      {:else}
+        {#if ownerUsername}
+          <p class="mt-4 text-sm text-slate-600 dark:text-smoke-400">
+            Eigentümer: <span class="font-medium text-gray-900 dark:text-smoke-100"
+              >@{ownerUsername}</span
+            >
+          </p>
+        {/if}
+
+        <!-- Add by username -->
+        <div class="mt-4">
+          <label
+            for="share-username"
+            class="block text-sm font-medium text-gray-700 dark:text-smoke-300"
+            >Event-Manager über Benutzernamen hinzufügen</label
+          >
+          <div class="mt-1 flex gap-2">
+            <input
+              id="share-username"
+              type="text"
+              autocomplete="off"
+              bind:value={usernameInput}
+              on:input={onInput}
+              on:keydown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addManager();
+                }
+              }}
+              class="flex-1 rounded-md border-gray-300 dark:border-charcoal-500 focus:ring-blue-500 focus:border-blue-500 px-3 py-2 text-sm bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100"
+              placeholder="Benutzername"
+            />
+            <button
+              type="button"
+              on:click={() => addManager()}
+              disabled={adding || usernameInput.trim().length === 0}
+              class="px-3 py-2 rounded-md text-sm font-medium text-white bg-blue-600 dark:bg-blue-700 hover:bg-blue-700 dark:hover:bg-blue-600 disabled:opacity-50"
+              >Hinzufügen</button
+            >
+          </div>
+          {#if suggestions.length}
+            <ul
+              class="mt-1 border border-gray-200 dark:border-charcoal-600 rounded-md divide-y divide-gray-100 dark:divide-charcoal-700 overflow-hidden"
+            >
+              {#each suggestions as s (s)}
+                <li>
+                  <button
+                    type="button"
+                    class="w-full text-left px-3 py-2 text-sm text-gray-700 dark:text-smoke-200 hover:bg-blue-50 dark:hover:bg-charcoal-700"
+                    on:click={() => addManager(s)}>@{s}</button
+                  >
+                </li>
+              {/each}
+            </ul>
+          {/if}
+          <p class="mt-1 text-[11px] text-slate-500 dark:text-smoke-500">
+            Andere Manager sehen nur Benutzernamen – keine persönlichen Daten.
+          </p>
+        </div>
+
+        <!-- Current grantees -->
+        <div class="mt-5">
+          <h4
+            class="text-sm font-medium text-gray-700 dark:text-smoke-300 mb-2"
+          >
+            Freigegeben für
+          </h4>
+          {#if managers.length === 0}
+            <p class="text-sm text-slate-500 dark:text-smoke-500">
+              Noch nicht geteilt.
+            </p>
+          {:else}
+            <ul class="space-y-2">
+              {#each managers as m (m.username)}
+                <li
+                  class="flex items-center justify-between rounded-md border border-gray-200 dark:border-charcoal-600 px-3 py-2"
+                >
+                  <span class="text-sm text-gray-900 dark:text-smoke-100"
+                    >@{m.username}</span
+                  >
+                  <button
+                    type="button"
+                    class="text-xs font-medium text-red-600 dark:text-red-400 hover:underline"
+                    on:click={() => removeManager(m.username)}>Entfernen</button
+                  >
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+
+        {#if canReassign}
+          <!-- Reassign owner (head admin only) -->
+          <div class="mt-5 pt-4 border-t border-gray-200 dark:border-charcoal-600">
+            <h4
+              class="text-sm font-medium text-gray-700 dark:text-smoke-300 mb-2"
+            >
+              Besitzer neu zuweisen
+            </h4>
+            <div class="flex gap-2">
+              <input
+                type="text"
+                autocomplete="off"
+                bind:value={reassignInput}
+                on:input={onReassignInput}
+                on:keydown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    reassignOwner();
+                  }
+                }}
+                class="flex-1 rounded-md border-gray-300 dark:border-charcoal-500 focus:ring-blue-500 focus:border-blue-500 px-3 py-2 text-sm bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100"
+                placeholder="Neuer Besitzer (Benutzername)"
+              />
+              <button
+                type="button"
+                on:click={() => reassignOwner()}
+                disabled={reassigning || reassignInput.trim().length === 0}
+                class="px-3 py-2 rounded-md text-sm font-medium text-white bg-amber-600 dark:bg-amber-700 hover:bg-amber-700 dark:hover:bg-amber-600 disabled:opacity-50"
+                >Zuweisen</button
+              >
+            </div>
+            {#if reassignSuggestions.length}
+              <ul
+                class="mt-1 border border-gray-200 dark:border-charcoal-600 rounded-md divide-y divide-gray-100 dark:divide-charcoal-700 overflow-hidden"
+              >
+                {#each reassignSuggestions as s (s)}
+                  <li>
+                    <button
+                      type="button"
+                      class="w-full text-left px-3 py-2 text-sm text-gray-700 dark:text-smoke-200 hover:bg-amber-50 dark:hover:bg-charcoal-700"
+                      on:click={() => reassignOwner(s)}>@{s}</button
+                    >
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+            <p class="mt-1 text-[11px] text-slate-500 dark:text-smoke-500">
+              Überträgt das Eigentum vollständig an einen anderen Manager.
+            </p>
+          </div>
+        {/if}
+      {/if}
+    </div>
+  </div>
+</Portal>

--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -18,7 +18,7 @@
       isLoading.set(true);
 
       // In a real app, this would be an API call
-      const response = await fetch("/api/events?limit=6&upcoming=true");
+      const response = await fetch("/api/events/upcoming?limit=6");
       if (response.ok) {
         const result = await response.json();
         const apiEvents = result.success ? result.data : [];

--- a/src/pages/admin/AdminEvents.svelte
+++ b/src/pages/admin/AdminEvents.svelte
@@ -4,6 +4,7 @@
   import { SvelteSet } from "svelte/reactivity";
   import User from "../../classes/User";
   import AdminLayout from "../../components/admin/AdminLayout.svelte";
+  import EventShareModal from "../../components/admin/EventShareModal.svelte";
   import RecurrenceBuilder from "../../components/admin/recurrence/RecurrenceBuilder.svelte";
   import SeriesManagement from "../../components/admin/SeriesManagement.svelte";
   import {
@@ -29,6 +30,9 @@
   let editingItem: any = null;
   let deleteConfirm: any = null;
   let currentUser: User | null = null;
+  // Record currently open in the share dialog (null = closed)
+  let shareTarget: { type: "event" | "series"; id: string; title: string } | null =
+    null;
 
   // Track which series details are expanded (persists across data refreshes)
   let expandedSeriesIds = new SvelteSet<string>();
@@ -307,14 +311,27 @@
     }
   }
 
-  function canDelete(_item: any): boolean {
+  function canDelete(item: any): boolean {
     if (!currentUser) return false;
     // Head & Admin: alles
     if (currentUser.role === "head" || currentUser.role === "admin")
       return true;
-    // Event-Manager: jetzt volle Verwaltung inkl. Serien-Löschung
-    if (currentUser.role === "event_manager") return true;
+    // Event-Manager: nur eigene Veranstaltungen (geteilte dürfen nur bearbeitet werden)
+    if (currentUser.role === "event_manager") return item?.is_owner === true;
     return false;
+  }
+
+  // Owner or admin/head may manage sharing; granted managers may not re-share.
+  function canShare(item: any): boolean {
+    if (!currentUser) return false;
+    if (currentUser.role === "head" || currentUser.role === "admin")
+      return true;
+    if (currentUser.role === "event_manager") return item?.is_owner === true;
+    return false;
+  }
+
+  function openShare(item: any, type: "event" | "series") {
+    shareTarget = { type, id: String(item.id), title: item.title };
   }
 
   // --- Erweiterte Formularlogik für neues Multi-Sektions-Formular ---
@@ -477,6 +494,14 @@
                             Featured
                           </span>
                         {/if}
+                        {#if event.owner_username}
+                          <span
+                            class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-slate-100 dark:bg-charcoal-700 text-slate-600 dark:text-smoke-400"
+                            title="Eigentümer"
+                          >
+                            @{event.owner_username}
+                          </span>
+                        {/if}
                       </div>
                       <div class="text-sm text-slate-700 dark:text-smoke-300">
                         {formatDate(event.start_datetime)} - {formatDate(
@@ -506,6 +531,14 @@
                           Entwurf
                         </button>
                       {/if}
+                      {#if canShare(event)}
+                        <button
+                          on:click={() => openShare(event, "event")}
+                          class="rounded-lg border border-indigo-100 dark:border-indigo-800 px-3 py-1 text-sm font-medium text-indigo-600 dark:text-indigo-400 transition hover:border-indigo-200 dark:hover:border-indigo-700 hover:bg-indigo-50 dark:hover:bg-indigo-900/30"
+                        >
+                          Teilen
+                        </button>
+                      {/if}
                       <button
                         on:click={() => openEditModal(event, "event")}
                         class="rounded-lg border border-blue-100 dark:border-blue-800 px-3 py-1 text-sm font-medium text-blue-600 dark:text-blue-400 transition hover:border-blue-200 dark:hover:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/30"
@@ -522,8 +555,8 @@
                       {:else if currentUser?.role === "event_manager"}
                         <span
                           class="text-xs text-slate-500"
-                          title="Nur vergangene Veranstaltungen können gelöscht werden"
-                          >(nur vergangene löschbar)</span
+                          title="Diese Veranstaltung wurde mit Ihnen geteilt – nur der Eigentümer kann sie löschen"
+                          >(geteilt)</span
                         >
                       {/if}
                     </div>
@@ -573,6 +606,14 @@
                         >
                           Serie
                         </span>
+                        {#if seriesItem.owner_username}
+                          <span
+                            class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-slate-100 dark:bg-charcoal-700 text-slate-600 dark:text-smoke-400"
+                            title="Eigentümer"
+                          >
+                            @{seriesItem.owner_username}
+                          </span>
+                        {/if}
                       </div>
                       <div
                         class="text-sm text-slate-700 dark:text-smoke-300 break-all"
@@ -604,6 +645,14 @@
                           class="rounded-lg border border-amber-200 dark:border-amber-700 px-3 py-1 text-sm font-medium text-amber-700 dark:text-amber-400 transition hover:bg-amber-50 dark:hover:bg-amber-900/30"
                         >
                           Entwurf
+                        </button>
+                      {/if}
+                      {#if canShare(seriesItem)}
+                        <button
+                          on:click={() => openShare(seriesItem, "series")}
+                          class="rounded-lg border border-indigo-100 dark:border-indigo-800 px-3 py-1 text-sm font-medium text-indigo-600 dark:text-indigo-400 transition hover:border-indigo-200 dark:hover:border-indigo-700 hover:bg-indigo-50 dark:hover:bg-indigo-900/30"
+                        >
+                          Teilen
                         </button>
                       {/if}
                       <button
@@ -1214,5 +1263,17 @@
         </div>
       </div>
     </Portal>
+  {/if}
+
+  <!-- Share / grant access modal -->
+  {#if shareTarget}
+    <EventShareModal
+      targetType={shareTarget.type}
+      targetId={shareTarget.id}
+      title={shareTarget.title}
+      canReassign={currentUser?.role === "head"}
+      on:changed={() => loadEvents()}
+      on:close={() => (shareTarget = null)}
+    />
   {/if}
 </AdminLayout>

--- a/src/pages/admin/AdminEvents.svelte
+++ b/src/pages/admin/AdminEvents.svelte
@@ -489,6 +489,23 @@
                     </div>
 
                     <div class="flex items-center gap-2 sm:self-start">
+                      {#if event.status === "draft"}
+                        <button
+                          on:click={() =>
+                            AdminAPI.updateEventStatus(event.id, "published")}
+                          class="rounded-lg border border-green-200 dark:border-green-700 px-3 py-1 text-sm font-medium text-green-700 dark:text-green-400 transition hover:bg-green-50 dark:hover:bg-green-900/30"
+                        >
+                          Veröffentlichen
+                        </button>
+                      {:else if event.status === "published"}
+                        <button
+                          on:click={() =>
+                            AdminAPI.updateEventStatus(event.id, "draft")}
+                          class="rounded-lg border border-amber-200 dark:border-amber-700 px-3 py-1 text-sm font-medium text-amber-700 dark:text-amber-400 transition hover:bg-amber-50 dark:hover:bg-amber-900/30"
+                        >
+                          Entwurf
+                        </button>
+                      {/if}
                       <button
                         on:click={() => openEditModal(event, "event")}
                         class="rounded-lg border border-blue-100 dark:border-blue-800 px-3 py-1 text-sm font-medium text-blue-600 dark:text-blue-400 transition hover:border-blue-200 dark:hover:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/30"
@@ -569,6 +586,26 @@
                     </div>
 
                     <div class="flex items-center gap-2 sm:self-start">
+                      {#if seriesItem.status === "draft"}
+                        <button
+                          on:click={() =>
+                            AdminAPI.updateEventStatus(
+                              seriesItem.id,
+                              "published",
+                            )}
+                          class="rounded-lg border border-green-200 dark:border-green-700 px-3 py-1 text-sm font-medium text-green-700 dark:text-green-400 transition hover:bg-green-50 dark:hover:bg-green-900/30"
+                        >
+                          Veröffentlichen
+                        </button>
+                      {:else if seriesItem.status === "published"}
+                        <button
+                          on:click={() =>
+                            AdminAPI.updateEventStatus(seriesItem.id, "draft")}
+                          class="rounded-lg border border-amber-200 dark:border-amber-700 px-3 py-1 text-sm font-medium text-amber-700 dark:text-amber-400 transition hover:bg-amber-50 dark:hover:bg-amber-900/30"
+                        >
+                          Entwurf
+                        </button>
+                      {/if}
                       <button
                         on:click={() => openEditModal(seriesItem, "series")}
                         class="rounded-lg border border-blue-100 dark:border-blue-800 px-3 py-1 text-sm font-medium text-blue-600 dark:text-blue-400 transition hover:border-blue-200 dark:hover:border-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/30"

--- a/src/stores/admin.ts
+++ b/src/stores/admin.ts
@@ -1013,6 +1013,80 @@ export class AdminAPI {
     return res;
   }
 
+  // Event sharing (per-event manager access)
+  // targetType selects the URL: 'series' → /events/series/{id}/managers, else /events/{id}/managers.
+  private static managersBase(targetType: "event" | "series", id: string) {
+    return targetType === "series"
+      ? `/events/series/${id}/managers`
+      : `/events/${id}/managers`;
+  }
+
+  static async getEventManagers(targetType: "event" | "series", id: string) {
+    return this.request(this.managersBase(targetType, id));
+  }
+
+  static async addEventManager(
+    targetType: "event" | "series",
+    id: string,
+    username: string,
+  ) {
+    const res = await this.request(this.managersBase(targetType, id), {
+      method: "POST",
+      body: JSON.stringify({ username }),
+    });
+    if (res.success) {
+      adminNotifications.success("Zugriff gewährt");
+    } else {
+      adminNotifications.error(res.message || "Fehler beim Teilen");
+    }
+    return res;
+  }
+
+  static async removeEventManager(
+    targetType: "event" | "series",
+    id: string,
+    username: string,
+  ) {
+    const res = await this.request(
+      `${this.managersBase(targetType, id)}?username=${encodeURIComponent(username)}`,
+      { method: "DELETE" },
+    );
+    if (res.success) {
+      adminNotifications.success("Zugriff entzogen");
+    } else {
+      adminNotifications.error(res.message || "Fehler beim Entziehen");
+    }
+    return res;
+  }
+
+  static async searchManagerCandidates(query: string) {
+    return this.request(
+      `/events/manager-search?q=${encodeURIComponent(query)}`,
+    );
+  }
+
+  // Head-admin only: reassign the owner of an event/series to another user.
+  static async reassignEventOwner(
+    targetType: "event" | "series",
+    id: string,
+    username: string,
+  ) {
+    const base =
+      targetType === "series"
+        ? `/events/series/${id}/owner`
+        : `/events/${id}/owner`;
+    const res = await this.request(base, {
+      method: "PUT",
+      body: JSON.stringify({ username }),
+    });
+    if (res.success) {
+      adminNotifications.success("Besitzer neu zugewiesen");
+    } else {
+      adminNotifications.error(res.message || "Fehler beim Neuzuweisen");
+    }
+    return res;
+  }
+
   // Users API
   static async getUsers() {
     return this.request("/users");

--- a/src/stores/admin.ts
+++ b/src/stores/admin.ts
@@ -576,6 +576,45 @@ export class AdminAPI {
     }
   }
 
+  static async updateEventStatus(id: string | number, status: string) {
+    // Temp events use Date.now() (number) as ID until the server responds.
+    // Real persisted events always have UUID string IDs — bail out early.
+    if (typeof id === "number") {
+      adminNotifications.error("Veranstaltung wird noch gespeichert – bitte kurz warten.");
+      return { success: false, message: "Event not yet persisted" };
+    }
+    const idStr = String(id);
+    // Optimistic update — both maps are safe no-ops for non-matching IDs
+    adminEventHelpers.updateEvent(idStr, { status });
+    adminEventHelpers.updateSeries(idStr, { status });
+
+    try {
+      const result = await this.request(`/events/${idStr}/status`, {
+        method: "PATCH",
+        body: JSON.stringify({ status }),
+      });
+
+      if (result.success) {
+        const msg =
+          status === "published"
+            ? "Veranstaltung veröffentlicht!"
+            : status === "draft"
+              ? "Veranstaltung als Entwurf gespeichert."
+              : "Status aktualisiert.";
+        adminNotifications.success(msg);
+      } else {
+        this.getEvents().catch(() => {});
+        adminNotifications.error(result.error || result.message || "Fehler beim Status-Update");
+      }
+
+      return result;
+    } catch {
+      this.getEvents().catch(() => {});
+      adminNotifications.error("Netzwerkfehler beim Status-Update");
+      return { success: false, message: "Network error" };
+    }
+  }
+
   static async deleteEvent(id: number) {
     // Optimistische Aktualisierung: Event sofort entfernen
     adminEventHelpers.removeEvent(id);

--- a/src/stores/adminData.ts
+++ b/src/stores/adminData.ts
@@ -2,7 +2,7 @@ import { writable } from "svelte/store";
 
 // Admin Data Stores für automatische Updates
 export interface AdminEvent {
-  id: number;
+  id: string | number;
   title: string;
   description: string;
   content: string;
@@ -60,7 +60,7 @@ export interface AdminUpdateEvent {
   type: "event" | "message";
   action: "create" | "update" | "delete";
   data?: any;
-  id?: number;
+  id?: string | number;
 }
 
 export const adminEventBus = writable<AdminUpdateEvent | null>(null);
@@ -73,18 +73,26 @@ export const adminEventHelpers = {
     adminEventBus.set({ type: "event", action: "create", data: event });
   },
 
-  updateEvent: (id: number, updates: Partial<AdminEvent>) => {
+  updateEvent: (id: string | number, updates: Partial<AdminEvent>) => {
+    const idStr = String(id);
     adminEvents.update((events) =>
       events.map((event) =>
-        event.id === id ? { ...event, ...updates } : event,
+        String(event.id) === idStr ? { ...event, ...updates } : event,
       ),
     );
     adminEventBus.set({ type: "event", action: "update", id, data: updates });
   },
 
-  removeEvent: (id: number) => {
-    adminEvents.update((events) => events.filter((event) => event.id !== id));
+  removeEvent: (id: string | number) => {
+    const idStr = String(id);
+    adminEvents.update((events) => events.filter((event) => String(event.id) !== idStr));
     adminEventBus.set({ type: "event", action: "delete", id });
+  },
+
+  updateSeries: (id: string, updates: Record<string, unknown>) => {
+    adminSeries.update((series) =>
+      series.map((s) => (s.id === id ? { ...s, ...updates } : s)),
+    );
   },
 
   // Messages

--- a/src/stores/adminData.ts
+++ b/src/stores/adminData.ts
@@ -26,6 +26,9 @@ export interface AdminEvent {
   updated_at: string;
   series_id?: string;
   instance_date?: string; // falls Override einer Serie
+  created_by?: number | null; // owning user id
+  owner_username?: string | null; // username of the owner (display only)
+  is_owner?: boolean; // true if the current user owns this event
 }
 
 export interface AdminMessage {


### PR DESCRIPTION
## Überblick

Promotion von `dev` → `main` (löst den **prod**-Deploy aus). Enthält **5 Commits**:

| Commit | Inhalt |
|---|---|
| `b2d0e64` | **Headline-Fix:** Kommende Events / Eventserien auf der Startseite (siehe unten) |
| `168141b` (#80) | Manager-basiertes Event-Ownership, Sharing & Head-Admin-Reassign |
| `e1a04a5` (#79) | Event-Management: Boolean-Validierung + neue Endpoints |
| `e12d539` (#78) | Upcoming-Events-Endpoint: Frontend nutzt `/api/events/upcoming`, Filter `start_datetime` → `end_datetime` |
| `a2167a6` | Fix: Boolean-Validierung des `force`-Parameters im `SetupController` |

## Headline-Fix: Kommende Events bei Eventserien

**Problem:** Die Startseite (`/api/events/upcoming`) las nur die `events`-Tabelle direkt. Eventserien existieren dort aber nicht als Zeilen — ihre Termine werden dynamisch per RRULE generiert. Folge: Bei Serien wurden die nächsten Termine **nicht** als kommende Events gewertet; sobald das Serien-Startdatum in der Vergangenheit lag, fehlten auch die aktuellen Iterationen komplett.

**Fix:** `EventsController::upcoming()` nutzt jetzt dieselbe Expansionslogik wie der Kalender (`getExpandedEvents` → Serien + Legacy-Recurring + Einzelevents über ein Fenster von 24 Monaten), filtert auf „noch nicht beendet" (`end_datetime > jetzt`), blendet abgesagte Instanzen aus, sortiert und limitiert.

**Live verifiziert auf beta:** `/api/events/upcoming?limit=6` lieferte vorher `[]`, jetzt 6 korrekte Serien-Termine (nächster 15.06.2026). Neuer Unit-Test `EventsControllerUpcomingTest` (5 Tests, 24 Assertions).

## Verifikation

- ✅ Beta (`dev`) deployed & live geprüft: Startseite zeigt kommende Serien-Termine.
- ✅ Backend-Unit-Tests grün für die geänderte Logik (`EventsControllerUpcomingTest`).
- ✅ #78/#79/#80 wurden als separate PRs bereits reviewt & auf `dev`/beta erprobt.

---

## ⚠️ Manuelle Schritte nach dem Merge (PROD)

> Der Merge nach `main` startet **automatisch** den prod-Deploy (GitHub Actions `Build and Deploy to SFTP` → Build + SFTP-Upload). Der Deploy führt **keine** DB-Migrationen aus und invalidiert keine Caches. Folgende Schritte sind **händisch** nötig:

1. **DB-Migrationen auf prod ausführen** (zwingend — sonst 500er bei Admin-Event-Endpoints):
   - Setup-Endpoint aufrufen: `https://hypnose-stammtisch.de/api/setup.php?action=migrate&token=<SETUP_TOKEN>` (Token aus GitHub-Secret `PROD_ENV`).
   - Neu in diesem Release: **010** (`idx_end_datetime` auf `events.end_datetime` — nötig, damit die umgestellten upcoming/featured-Queries keinen Full-Table-Scan machen) und **011** (`created_by`-Spalten + `event_access`-Tabelle + Foreign Keys + Owner-Backfill).
   - Prüfen, ob prod ggf. noch hinter dev liegt (z. B. **009** `stammtisch_locations`) und alle pending Migrationen mitlaufen.

2. **Vor/bei Migration 011 sicherstellen, dass ein Head-Admin existiert.**
   Der Backfill setzt `created_by` auf den `role='head'`-User mit der niedrigsten id. Existiert auf prod **kein** Head-Admin, bleiben bestehende Events/Serien ownerless (`created_by = NULL`) → Event-Manager sehen sie dann nicht; nur Head/Admin können sie verwalten. Ggf. nach Anlegen des Head-Admins die Owner über den Reassign-Endpoint bzw. direkt in der DB setzen.

3. **Migrationsstatus verifizieren:** In der `migrations`-Tabelle prüfen, dass Versionen bis **011** eingetragen sind. (Bekannte Eigenheiten des Runners bzgl. doppelter Versionsnummern/DELIMITER beachten.)

4. **Prod-Funktionsprüfung nach Deploy + Migration:**
   - `GET https://hypnose-stammtisch.de/api/events/upcoming?limit=6` → liefert Serien-Instanzen statt `[]`.
   - Startseite zeigt „Kommende Veranstaltungen".
   - Admin-UI: Teilen-Dialog (Manager hinzufügen/entfernen), Status-PATCH und Owner-Reassign (als Head-Admin) funktionieren.

5. **Caching:** Falls vor der Startseite/API ein CDN- oder Browser-Cache greift, Cache invalidieren, damit die neuen Events erscheinen.

---

## Offene Punkte / Follow-ups (nicht blockierend)

- `Event::getUpcoming()` (+ Mock-Fallback) ist durch den Headline-Fix **ungenutzt** geworden (toter Code) — kann in einem Folge-PR entfernt werden.
- Bestand (#80): einige Manager/Owner-Fehlerantworten geben `$e->getMessage()` direkt an den Client zurück (mögliche Info-Disclosure), anders als `patchStatus`, das hinter `app.debug` gated ist — optionales Hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
