### PR TITLE
refactor: toten Code Event::getUpcoming() entfernen (#82)

### DIFF
--- a/backend/src/Controllers/EventsController.php
+++ b/backend/src/Controllers/EventsController.php
@@ -255,9 +255,10 @@ class EventsController
 
             // Expand legacy recurring events and series (event_series) into concrete
             // instances so recurring offers whose base/start date lies in the past
-            // still contribute their upcoming occurrences. Querying the events table
-            // alone (Event::getUpcoming) misses dynamically generated series instances
-            // entirely and drops recurring rows once their original date has passed.
+            // still contribute their upcoming occurrences. A plain published +
+            // end_datetime query against the events table alone misses dynamically
+            // generated series instances entirely and drops recurring rows once their
+            // original date has passed.
             //
             // The lower bound is widened by a day so the timezone offset between the
             // UTC-stored events table and the local wall-clock reference cannot drop a

--- a/backend/src/Models/Event.php
+++ b/backend/src/Models/Event.php
@@ -115,29 +115,6 @@ class Event
     }
 
     /**
-     * Get upcoming events
-     */
-    public static function getUpcoming(int $limit = 5): array
-    {
-        try {
-            $sql = "SELECT * FROM events
-                    WHERE status = 'published'
-                    AND end_datetime > UTC_TIMESTAMP()
-                    ORDER BY start_datetime ASC
-                    LIMIT ?";
-
-            $rows = Database::fetchAll($sql, [$limit]);
-
-            return array_map([self::class, 'fromArray'], $rows);
-        } catch (\Exception $e) {
-            error_log("Database error in getUpcoming, using mock data: " . $e->getMessage());
-
-            $mockEvents = MockData::getUpcomingEvents($limit);
-            return MockData::getMockEventObjects(['limit' => $limit, 'upcoming_only' => true]);
-        }
-    }
-
-    /**
      * Get featured events
      */
     public static function getFeatured(int $limit = 3): array

--- a/backend/src/Utils/MockData.php
+++ b/backend/src/Utils/MockData.php
@@ -216,26 +216,6 @@ class MockData
     }
 
     /**
-     * Get upcoming events
-     */
-    public static function getUpcomingEvents(int $limit = 10): array
-    {
-        $events = self::getEvents();
-
-        // Filter for upcoming events
-        $upcoming = array_filter($events, function ($event) {
-            return strtotime($event['start_date']) >= strtotime('today');
-        });
-
-        // Sort by start date
-        usort($upcoming, function ($a, $b) {
-            return strtotime($a['start_date']) - strtotime($b['start_date']);
-        });
-
-        return array_slice($upcoming, 0, $limit);
-    }
-
-    /**
      * Get featured events
      */
     public static function getFeaturedEvents(int $limit = 5): array

--- a/backend/tests/Unit/Controllers/EventsControllerUpcomingTest.php
+++ b/backend/tests/Unit/Controllers/EventsControllerUpcomingTest.php
@@ -15,9 +15,9 @@ use ReflectionMethod;
  * Regression coverage for the upcoming-events endpoint.
  *
  * The homepage "Kommende Veranstaltungen" widget previously read the events table
- * directly (Event::getUpcoming), so recurring series whose start/base date lies in
- * the past contributed no upcoming occurrences at all. upcoming() now expands
- * series + legacy recurring events and keeps only the ones that have not ended.
+ * directly, so recurring series whose start/base date lies in the past contributed
+ * no upcoming occurrences at all. upcoming() now expands series + legacy recurring
+ * events and keeps only the ones that have not ended.
  */
 class EventsControllerUpcomingTest extends TestCase
 {


### PR DESCRIPTION
Behebt #82

## Was
`EventsController::upcoming()` nutzt seit PR #81 die Expansionslogik `getExpandedEvents()`, dadurch wird `Event::getUpcoming()` nie mehr aufgerufen — toter Code (inkl. einer toten `$mockEvents`-Zuweisung im Catch-Block).

## Änderungen
- `Event::getUpcoming()` entfernt (`backend/src/Models/Event.php`).
- `MockData::getUpcomingEvents()` entfernt — `Event::getUpcoming()` war der einzige Aufrufer.
- Verbliebene `Event::getUpcoming`-Referenzen aus zwei Kommentaren (`EventsController`, Test) entfernt, damit niemand künftig in einer nicht mehr existierenden Methode debuggt.

## Verifikation
- `grep` bestätigt keine weiteren Aufrufer.
- Backend-Testsuite unverändert zum Baseline-Stand (keine neuen Fehler), `php -l` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)