### PR TITLE
fix: Backend-Antwort per E-Mail – Absenderadressen bereitstellen & Feld-Mapping (#96)

### DIFF
--- a/backend/migrations/012_seed_admin_email_addresses.sql
+++ b/backend/migrations/012_seed_admin_email_addresses.sql
@@ -1,0 +1,16 @@
+-- Migration 012: Seed a default sender address for admin_email_addresses
+-- The "reply by email" backend feature (AdminMessagesController::getEmailAddresses)
+-- only returns rows WHERE is_active = 1. On SFTP + migrate-endpoint deploys the
+-- table is otherwise populated solely by the CLI setup (setupEmailAddresses), which
+-- never runs in that pipeline — so on beta/prod the "Absender" dropdown stays empty
+-- and no reply can be sent. Seed one active default address so replying works out
+-- of the box. Mirrors the default used by setupEmailAddresses() (contact.general).
+--
+-- Idempotent + non-destructive: the row is only inserted when the table has no rows
+-- at all, so an environment already configured via the CLI setup or the admin UI is
+-- left untouched (we never add a competing default to an existing configuration).
+-- NOTE: never add `INSERT INTO migrations` here; the runner records the version itself.
+
+INSERT INTO admin_email_addresses (email, display_name, department, is_default, is_active)
+SELECT 'info@hypnose-stammtisch.de', 'Allgemein', 'allgemein', 1, 1 FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM admin_email_addresses);

--- a/src/components/admin/AdminMessageResponse.svelte
+++ b/src/components/admin/AdminMessageResponse.svelte
@@ -7,11 +7,14 @@
   export let contactName: string = "";
   export let originalSubject: string = "";
 
+  // Field names mirror the backend payload from
+  // AdminMessagesController::getEmailAddresses (display_name/department, not name/description).
   interface EmailAddress {
     id: number;
-    name: string;
     email: string;
-    description: string;
+    display_name: string;
+    department: string;
+    is_default?: boolean | number;
   }
 
   interface MessageResponse {
@@ -147,17 +150,27 @@
           >
             Absender
           </label>
-          <select
-            id="from-email-select"
-            bind:value={selectedEmailId}
-            class="w-full px-3 py-2 border border-gray-300 dark:border-charcoal-600 bg-white dark:bg-charcoal-800 text-gray-900 dark:text-smoke-50 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-          >
-            {#each emailAddresses as emailAddr (emailAddr.id)}
-              <option value={emailAddr.id}>
-                {emailAddr.name} ({emailAddr.email}) - {emailAddr.description}
-              </option>
-            {/each}
-          </select>
+          {#if emailAddresses.length === 0}
+            <div
+              class="px-3 py-2 text-sm rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-300"
+            >
+              Keine aktiven Absendeadressen konfiguriert. Bitte zuerst (z.&nbsp;B.
+              über das Setup oder eine Migration) mindestens eine aktive
+              Absendeadresse anlegen, um per E-Mail antworten zu können.
+            </div>
+          {:else}
+            <select
+              id="from-email-select"
+              bind:value={selectedEmailId}
+              class="w-full px-3 py-2 border border-gray-300 dark:border-charcoal-600 bg-white dark:bg-charcoal-800 text-gray-900 dark:text-smoke-50 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+              {#each emailAddresses as emailAddr (emailAddr.id)}
+                <option value={emailAddr.id}>
+                  {emailAddr.display_name} ({emailAddr.email}) - {emailAddr.department}
+                </option>
+              {/each}
+            </select>
+          {/if}
         </div>
 
         <!-- To Email (readonly) -->


### PR DESCRIPTION
Behebt #96

## Problem
Im Admin-Backend war eine Antwort per E-Mail nicht möglich: das „Absender"-Dropdown war leer, ein Versand somit blockiert.

Zwei Ursachen:
1. **`admin_email_addresses` leer auf beta/prod.** Die Tabelle wird nur vom CLI-Setup (`setupEmailAddresses`) befüllt, das im SFTP-+-Migrations-Deploy nie läuft → `getEmailAddresses()` liefert `[]`.
2. **Feld-Mismatch.** Frontend las `name`/`description`, Backend liefert `display_name`/`department` → Labels undefined.

## Änderungen
- **Seed-Migration `012_seed_admin_email_addresses.sql`**: legt eine aktive Default-Absenderadresse an (`info@hypnose-stammtisch.de`, analog `setupEmailAddresses()`/`contact.general`). Idempotent und nicht-destruktiv — seedet nur, wenn die Tabelle komplett leer ist, sodass bereits konfigurierte Umgebungen unangetastet bleiben.
- **Frontend-Mapping korrigiert** (`AdminMessageResponse.svelte`): `EmailAddress`-Interface und Template auf `display_name`/`department` umgestellt.
- **UX-Härtung**: Bei 0 aktiven Adressen wird statt eines leeren Dropdowns ein Hinweis angezeigt; der Senden-Button bleibt deaktiviert, solange kein Absender gewählt ist.

## Verifikation
- `svelte-check`: keine Probleme für `AdminMessageResponse.svelte` (verbleibende Fehler sind vorbestehend, fehlende `@types/node`).
- Migration parst über `SqlStatementParser` zu genau einem Statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)