### PR TITLE
fix(email): send replies from the authenticated SMTP identity (#101)

### DIFF
--- a/backend/src/Utils/EmailService.php
+++ b/backend/src/Utils/EmailService.php
@@ -360,10 +360,15 @@ TEXT;
         try {
             $mail = self::createMailer();
 
-            // Override the from address with the selected sender
-            $mail->setFrom($fromEmail, $fromName);
+            // Always send with the authenticated SMTP identity as the envelope
+            // From address so the relay accepts the mail and SPF/DKIM/DMARC line
+            // up — a misconfigured admin_email_addresses row must not be able to
+            // break delivery. The selected sender is surfaced to the recipient
+            // via the From display name and the Reply-To address instead.
+            $fromAddress = (string) Config::get('mail.from_email', $fromEmail);
+            $mail->setFrom($fromAddress, $fromName);
 
-            // Set reply-to (defaults to from address)
+            // Replies go to the selected admin address (falls back to it directly).
             $mail->addReplyTo($replyTo ?? $fromEmail, $fromName);
 
             // Add recipient


### PR DESCRIPTION
## Kontext

Bezieht sich auf #101 (gefunden im Code-Review von #100).

`EmailService::sendMessageResponse()` setzte die in der Admin-UI gewählte `admin_email_addresses`-Zeile als **SMTP-`From`-Adresse**. Ist diese Adresse auf dem Prod-SMTP-Account **nicht** sendeberechtigt, lehnt der Relay die Mail ab oder sie scheitert an SPF/DKIM/DMARC und landet im Spam/wird verworfen — die Antwort-Funktion bleibt faktisch kaputt.

## Änderung (Folge-Hardening aus dem Ticket)

`setFrom` wird an die **authentifizierte Sende-Identität** gebunden:

- `From`-Adresse = `mail.from_email` (`MAIL_FROM_ADDRESS`) → Relay-Akzeptanz und SPF/DKIM/DMARC-Alignment sind garantiert
- Die gewählte Absenderadresse wird weiterhin sichtbar gemacht — als **Anzeigename** im `From` und als **`Reply-To`** (Antworten gehen an die richtige Stelle)
- Fallback auf die gewählte Adresse, falls `mail.from_email` leer ist

Damit kann eine fehlkonfigurierte `admin_email_addresses`-Zeile den Versand nicht mehr brechen.

## Test

- `php -l`: keine Syntaxfehler
- `phpcs --standard=phpcs.xml`: keine **neuen** Befunde (die vorhandenen EOL-/Zeilenlängen-Meldungen bestehen auch ohne diese Änderung)

> Hinweis: Die im Ticket genannten **operativen** Schritte (aktive Absendeadresse nach Migration 012 ggf. auf den korrekten Wert korrigieren, echte Test-Antwort versenden und Zustellung inkl. SPF/DKIM/DMARC bestätigen) bleiben ein manueller Schritt auf der Zielumgebung und sind nicht Teil dieses Codediffs.

Refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)