### PR TITLE
ci(migrations): add MariaDB smoke test + fix fresh-install bug in 008 (#102)

### DIFF
--- a/.github/workflows/migrations-smoke-test.yml
+++ b/.github/workflows/migrations-smoke-test.yml
@@ -1,0 +1,110 @@
+name: Migrations Smoke Test
+
+# The production deploy runs migrations as a manual step against the live DB,
+# and neither the migration runner nor phpunit run in CI. This workflow
+# exercises every migration against a real database service from a clean
+# schema so a broken or non-idempotent migration is caught here instead of on
+# first execution against prod (see issue #102).
+#
+# Engine: MariaDB. The migrations use MariaDB-flavoured idioms (CREATE INDEX
+# IF NOT EXISTS, ALTER TABLE ... ADD COLUMN IF NOT EXISTS) that plain MySQL
+# rejects, and prod runs on Hetzner shared hosting (MariaDB), so we must test
+# against MariaDB to mirror production.
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - "backend/migrations/**"
+      - "backend/src/Config/**"
+      - "backend/src/Database/**"
+      - "backend/src/Utils/SqlStatementParser.php"
+      - "backend/composer.json"
+      - "backend/composer.lock"
+      - "backend/scripts/ci_verify_migrations.php"
+      - ".github/workflows/migrations-smoke-test.yml"
+  pull_request:
+    branches:
+      - dev
+      - main
+    paths:
+      - "backend/migrations/**"
+      - "backend/src/Config/**"
+      - "backend/src/Database/**"
+      - "backend/src/Utils/SqlStatementParser.php"
+      - "backend/composer.json"
+      - "backend/composer.lock"
+      - "backend/scripts/ci_verify_migrations.php"
+      - ".github/workflows/migrations-smoke-test.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  migrate-mariadb:
+    name: Run migrations against MariaDB
+    runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: hypnose_stammtisch
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          extensions: pdo, pdo_mysql, mbstring, json, openssl
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Create .env pointing at the MariaDB service
+        run: |
+          cat > .env <<'EOF'
+          DB_HOST=127.0.0.1
+          DB_PORT=3306
+          DB_NAME=hypnose_stammtisch
+          DB_USER=root
+          DB_PASS=root
+          APP_ENV=testing
+          APP_DEBUG=true
+          # Use a fixed UTC offset rather than a named zone: the ephemeral CI
+          # MariaDB has no timezone tables loaded, so `SET time_zone = 'Europe/Berlin'`
+          # would fail. Migrations do not depend on the session timezone.
+          CALENDAR_TIMEZONE=+00:00
+          EOF
+
+      - name: Run migrations (first pass)
+        run: php migrations/migrate.php migrate
+
+      - name: Run migrations again (idempotency)
+        run: |
+          php migrations/migrate.php migrate | tee second-run.log
+          if ! grep -q "No new migrations to execute." second-run.log; then
+            echo "::error::Second migrate run was not a no-op — migrations are not idempotent."
+            exit 1
+          fi
+
+      - name: Verify seed + recorded versions
+        run: php scripts/ci_verify_migrations.php

--- a/backend/migrations/008_rename_contact_telegram_to_fetlife.sql
+++ b/backend/migrations/008_rename_contact_telegram_to_fetlife.sql
@@ -2,6 +2,13 @@
 -- Safe: only renames if the column still exists under the old name.
 -- Fresh installs: table does not yet exist (created in 009), so this is a no-op.
 -- Existing installs: renames the column if needed.
+--
+-- The no-op branch must NOT return a client result set: the migration runner
+-- executes each statement via PDO::exec(), and an unconsumed result set (e.g.
+-- from EXECUTE-ing a `SELECT`) leaves the connection with an active cursor,
+-- breaking the following DEALLOCATE with "unbuffered queries are active"
+-- (errno 2014) on a fresh database. `SET @var` is preparable and returns no
+-- result set, so both branches stay result-set free.
 
 SELECT IF(
   (SELECT COUNT(*) FROM information_schema.COLUMNS
@@ -9,7 +16,7 @@ SELECT IF(
      AND TABLE_NAME   = 'stammtisch_locations'
      AND COLUMN_NAME  = 'contact_telegram') > 0,
   'ALTER TABLE stammtisch_locations CHANGE COLUMN contact_telegram contact_fetlife VARCHAR(100)',
-  'SELECT 1'
+  'SET @_rename_noop = 1'
 ) INTO @_rename_sql;
 
 PREPARE _rename_stmt FROM @_rename_sql;

--- a/backend/scripts/ci_verify_migrations.php
+++ b/backend/scripts/ci_verify_migrations.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CI smoke-test assertion for the database migration runner.
+ *
+ * Run AFTER `php migrations/migrate.php migrate` has executed (ideally twice,
+ * to also cover idempotency). Verifies against the live database connection that:
+ *
+ *   1. every migration file NNN_*.sql is recorded in the `migrations` table,
+ *   2. migration 012 in particular seeded exactly one row into
+ *      `admin_email_addresses` (and re-running the runner did not add a second),
+ *   3. that seeded row matches the expected default sender.
+ *
+ * Exits non-zero with a human-readable message on the first failed assertion so
+ * the workflow step fails loudly instead of silently passing.
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use HypnoseStammtisch\Config\Config;
+use HypnoseStammtisch\Database\Database;
+
+Config::load(__DIR__ . '/..');
+
+$failures = [];
+
+function check(array &$failures, string $label, bool $ok, string $detail = ''): void
+{
+    $status = $ok ? 'OK  ' : 'FAIL';
+    echo "[{$status}] {$label}" . ($detail !== '' ? " — {$detail}" : '') . PHP_EOL;
+    if (!$ok) {
+        $failures[] = $label;
+    }
+}
+
+$pdo = Database::getConnection();
+
+// 1. Every migration file must be recorded in the migrations table.
+$migrationDir = __DIR__ . '/../migrations';
+$files = glob($migrationDir . '/[0-9][0-9][0-9]_*.sql') ?: [];
+$expectedVersions = [];
+foreach ($files as $file) {
+    $expectedVersions[substr(basename($file), 0, 3)] = true;
+}
+$expectedVersions = array_keys($expectedVersions);
+sort($expectedVersions, SORT_STRING);
+
+$recorded = $pdo->query('SELECT version FROM migrations')->fetchAll(PDO::FETCH_COLUMN);
+$missing = array_diff($expectedVersions, $recorded);
+check(
+    $failures,
+    'all migration files recorded in migrations table',
+    $missing === [],
+    $missing === []
+        ? count($expectedVersions) . ' versions recorded'
+        : 'missing: ' . implode(', ', $missing)
+);
+
+// 2. Migration 012 specifically must be recorded.
+check(
+    $failures,
+    'migration 012 recorded',
+    in_array('012', $recorded, true)
+);
+
+// 3. Migration 012 seeded exactly one admin email address (idempotency).
+$count = (int) $pdo->query('SELECT COUNT(*) FROM admin_email_addresses')->fetchColumn();
+check(
+    $failures,
+    'admin_email_addresses seeded exactly once (idempotent)',
+    $count === 1,
+    "row count = {$count}"
+);
+
+// 4. The seeded row matches the expected default sender.
+$row = $pdo->query(
+    'SELECT email, is_default, is_active FROM admin_email_addresses LIMIT 1'
+)->fetch(PDO::FETCH_ASSOC);
+$rowOk = $row !== false
+    && $row['email'] === 'info@hypnose-stammtisch.de'
+    && (int) $row['is_default'] === 1
+    && (int) $row['is_active'] === 1;
+check(
+    $failures,
+    'seeded default sender matches migration 012',
+    $rowOk,
+    $row === false ? 'no row found' : json_encode($row)
+);
+
+echo PHP_EOL;
+if ($failures !== []) {
+    echo 'Migration verification FAILED: ' . implode('; ', $failures) . PHP_EOL;
+    exit(1);
+}
+
+echo 'Migration verification passed.' . PHP_EOL;


### PR DESCRIPTION
## Kontext

Bezieht sich auf #102 (optionale Folge-Hardening: „Migrate-Endpoint / Smoke-Test in CI gegen eine MySQL-Service-DB ergänzen").

Bisher läuft **weder** der Migrations-Runner **noch** phpunit in CI, und Migrationen sind ein manueller Schritt beim Deploy — eine kaputte Migration würde also erstmals **auf Prod** ausgeführt.

## Was dieser PR macht

### 1. Neuer CI-Smoke-Test (`.github/workflows/migrations-smoke-test.yml`)

- Spinnt einen **frischen MariaDB 10.11**-Service hoch und führt **alle** Migrationen von leerem Schema aus
- Läuft den Runner **zweimal** → prüft **Idempotenz** (zweiter Lauf = No-op)
- `backend/scripts/ci_verify_migrations.php` prüft anschließend: jede Version in der `migrations`-Tabelle vermerkt, **Migration 012 hat genau eine** Zeile in `admin_email_addresses` geseedet, und diese matcht den erwarteten Default-Absender
- Triggert auf Push/PR nach `dev`/`main`, gefiltert auf migrations-/DB-/runner-relevante Pfade

> **Warum MariaDB statt MySQL?** Das Ticket spricht von „MySQL", aber die Migrationen nutzen MariaDB-Idiome (`CREATE INDEX IF NOT EXISTS`, `ALTER TABLE … ADD COLUMN IF NOT EXISTS`), die **reines MySQL ablehnt**. Prod läuft auf Hetzner Shared Hosting (MariaDB). Ein MySQL-8-Container schlug bei Migration 006 sofort an dieser Syntax fehl — der Test muss gegen MariaDB laufen, um Prod zu spiegeln.

### 2. Bugfix in Migration 008 (vom Smoke-Test aufgedeckt)

Der Smoke-Test hat **sofort einen echten Fresh-Install-Bug** gefunden:

Auf einer frischen DB existiert `stammtisch_locations` noch nicht (wird erst in 009 angelegt), daher nimmt Migration 008 ihren No-op-Pfad. Dieser `PREPARE/EXECUTE`-te ein `SELECT 1`, das ein **Result-Set** liefert. Der Runner führt Statements via `PDO::exec()` aus und konsumiert das Result-Set nicht → der folgende `DEALLOCATE` bricht mit **Error 2014** („unbuffered queries are active") ab und der **gesamte** Migrationslauf scheitert bei 008.

Bestehende Installs waren nicht betroffen, weil sie den `ALTER`-(DDL-)Pfad nahmen (kein Result-Set) — der Bug trifft also **nur Clean-Schema-Läufe** (neue Umgebungen + dieser CI-Test). Fix: No-op auf `SET @_rename_noop = 1` umgestellt (preparable, kein Result-Set).

## Lokale Verifikation

Vollständig lokal gegen **MariaDB 10.11** mit **PHP 8.3.31** (CI-identisch) reproduziert:

```
=== FIRST RUN ===  → 12 migrations completed successfully
=== SECOND RUN === → No new migrations to execute.  (IDEMPOTENCY OK)
=== VERIFY ===
[OK] all migration files recorded in migrations table — 12 versions recorded
[OK] migration 012 recorded
[OK] admin_email_addresses seeded exactly once (idempotent) — row count = 1
[OK] seeded default sender matches migration 012 — {"email":"info@hypnose-stammtisch.de","is_default":1,"is_active":1}
```

> Die im Ticket genannten **operativen** Schritte (012 zuerst auf beta/dev über den Migrate-Endpoint ausführen, dann Prod) bleiben davon unberührt — dieser PR automatisiert genau die Verifikation, die das verhindern sollte.

Refs #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)