### PR TITLE
fix(admin): E-Mail-Bestätigung als echte Seite + ausstehend-Status (#109)

### DIFF
--- a/backend/src/Controllers/UserEmailConfirmController.php
+++ b/backend/src/Controllers/UserEmailConfirmController.php
@@ -28,8 +28,12 @@ class UserEmailConfirmController
             return;
         }
 
+        // Read "now" from the database in the same query so the TTL comparison
+        // is independent of the PHP timezone: both timestamps come from the DB
+        // clock, so any DB<->PHP offset cancels out.
         $row = Database::fetchOne(
-            'SELECT id, pending_email, email_change_requested_at FROM users WHERE email_change_token = ? AND pending_email IS NOT NULL',
+            'SELECT id, pending_email, email_change_requested_at, CURRENT_TIMESTAMP AS db_now
+             FROM users WHERE email_change_token = ? AND pending_email IS NOT NULL',
             [$token]
         );
 
@@ -40,9 +44,11 @@ class UserEmailConfirmController
 
         // Reject (and clean up) links whose request is older than the TTL.
         $requestedAt = $row['email_change_requested_at'] ?? null;
-        if ($requestedAt !== null) {
+        $dbNow = $row['db_now'] ?? null;
+        if ($requestedAt !== null && $dbNow !== null) {
             $requestedTs = strtotime((string)$requestedAt);
-            if ($requestedTs !== false && (time() - $requestedTs) > self::TOKEN_TTL_SECONDS) {
+            $nowTs = strtotime((string)$dbNow);
+            if ($requestedTs !== false && $nowTs !== false && ($nowTs - $requestedTs) > self::TOKEN_TTL_SECONDS) {
                 Database::execute(
                     'UPDATE users SET pending_email = NULL, email_change_token = NULL, email_change_requested_at = NULL WHERE id = ?',
                     [$row['id']]

--- a/backend/src/Controllers/UserEmailConfirmController.php
+++ b/backend/src/Controllers/UserEmailConfirmController.php
@@ -4,25 +4,114 @@ declare(strict_types=1);
 
 namespace HypnoseStammtisch\Controllers;
 
+use HypnoseStammtisch\Config\Config;
 use HypnoseStammtisch\Database\Database;
-use HypnoseStammtisch\Utils\Response;
 use HypnoseStammtisch\Utils\AuditLogger;
 
 class UserEmailConfirmController
 {
+    /** Confirmation links stay valid for 24 hours after the change was requested. */
+    private const TOKEN_TTL_SECONDS = 86400;
+
+    /**
+     * Confirm a pending email change.
+     *
+     * This endpoint is opened directly by the user's browser from the link in
+     * the confirmation mail, so it renders a self-contained HTML page instead
+     * of a JSON API response (the previous behaviour showed raw JSON, which
+     * looked like the link was broken).
+     */
     public static function confirm(string $token): void
     {
-        if (!$token) {
-            Response::error('Invalid token', 400);
+        if ($token === '') {
+            self::renderPage(400, false, 'Ungültiger Link', 'Der Bestätigungslink ist unvollständig.');
             return;
         }
-        $row = Database::fetchOne('SELECT id, pending_email FROM users WHERE email_change_token = ? AND pending_email IS NOT NULL', [$token]);
+
+        $row = Database::fetchOne(
+            'SELECT id, pending_email, email_change_requested_at FROM users WHERE email_change_token = ? AND pending_email IS NOT NULL',
+            [$token]
+        );
+
         if (!$row) {
-            Response::error('Token ungültig oder abgelaufen', 400);
+            self::renderPage(400, false, 'Link ungültig', 'Dieser Bestätigungslink ist ungültig oder wurde bereits verwendet.');
             return;
         }
-        Database::execute('UPDATE users SET email = pending_email, pending_email = NULL, email_change_token = NULL, email_change_requested_at = NULL WHERE id = ?', [$row['id']]);
+
+        // Reject (and clean up) links whose request is older than the TTL.
+        $requestedAt = $row['email_change_requested_at'] ?? null;
+        if ($requestedAt !== null) {
+            $requestedTs = strtotime((string)$requestedAt);
+            if ($requestedTs !== false && (time() - $requestedTs) > self::TOKEN_TTL_SECONDS) {
+                Database::execute(
+                    'UPDATE users SET pending_email = NULL, email_change_token = NULL, email_change_requested_at = NULL WHERE id = ?',
+                    [$row['id']]
+                );
+                AuditLogger::log('user.email_change_expired', 'user', (string)$row['id']);
+                self::renderPage(400, false, 'Link abgelaufen', 'Dieser Bestätigungslink ist abgelaufen. Bitte fordere die E-Mail-Änderung erneut an.');
+                return;
+            }
+        }
+
+        try {
+            Database::execute(
+                'UPDATE users SET email = pending_email, pending_email = NULL, email_change_token = NULL, email_change_requested_at = NULL WHERE id = ?',
+                [$row['id']]
+            );
+        } catch (\Throwable $e) {
+            // Most likely a UNIQUE violation because the address was taken in
+            // the meantime. Keep the pending change so the user can retry and
+            // still show a friendly page instead of a raw 500.
+            error_log('Email change confirmation failed: ' . $e->getMessage());
+            self::renderPage(409, false, 'Bestätigung fehlgeschlagen', 'Die E-Mail-Adresse konnte nicht bestätigt werden. Möglicherweise wird sie bereits von einem anderen Konto verwendet.');
+            return;
+        }
+
         AuditLogger::log('user.email_confirmed', 'user', (string)$row['id']);
-        Response::success(['email_confirmed' => true], 'E-Mail erfolgreich bestätigt');
+
+        self::renderPage(200, true, 'E-Mail bestätigt', 'Deine neue E-Mail-Adresse wurde erfolgreich bestätigt. Du kannst dich jetzt mit ihr anmelden.');
+    }
+
+    /**
+     * Render a minimal, self-contained confirmation result page.
+     */
+    private static function renderPage(int $status, bool $success, string $heading, string $message): void
+    {
+        if (!headers_sent()) {
+            http_response_code($status);
+            header('Content-Type: text/html; charset=utf-8');
+            header('Cache-Control: no-cache, no-store, must-revalidate');
+        }
+
+        $appName = htmlspecialchars(Config::getAppName(), ENT_QUOTES, 'UTF-8');
+        $heading = htmlspecialchars($heading, ENT_QUOTES, 'UTF-8');
+        $message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+        $loginUrl = htmlspecialchars(
+            rtrim((string)Config::get('app.url', ''), '/') . '/#/admin/login',
+            ENT_QUOTES,
+            'UTF-8'
+        );
+        $accent = $success ? '#16a34a' : '#dc2626';
+        $icon = $success ? '✓' : '✕';
+
+        echo <<<HTML
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{$heading} – {$appName}</title>
+</head>
+<body style="font-family: Arial, sans-serif; background:#f4f4f4; color:#333; margin:0; padding:40px 20px;">
+  <div style="max-width:520px; margin:0 auto; background:#fff; border-radius:8px; padding:32px; box-shadow:0 1px 4px rgba(0,0,0,.08); text-align:center;">
+    <div style="width:56px; height:56px; line-height:56px; margin:0 auto 16px; border-radius:50%; background:{$accent}; color:#fff; font-size:28px;">{$icon}</div>
+    <h1 style="margin:0 0 12px; font-size:22px; color:{$accent};">{$heading}</h1>
+    <p style="margin:0 0 24px; line-height:1.6;">{$message}</p>
+    <a href="{$loginUrl}" style="display:inline-block; background:#5a67d8; color:#fff; padding:12px 28px; border-radius:6px; text-decoration:none;">Zum Admin-Login</a>
+  </div>
+  <p style="text-align:center; color:#999; font-size:12px; margin-top:24px;">© {$appName}</p>
+</body>
+</html>
+HTML;
     }
 }

--- a/backend/src/Middleware/AdminAuth.php
+++ b/backend/src/Middleware/AdminAuth.php
@@ -88,7 +88,7 @@ class AdminAuth
             return null;
         }
 
-        $sql = "SELECT id, username, email, role, is_active, last_login, created_at, updated_at
+        $sql = "SELECT id, username, email, pending_email, role, is_active, last_login, created_at, updated_at
             FROM users WHERE id = ? AND is_active = 1";
         $user = Database::fetchOne($sql, [$_SESSION['admin_user_id']]);
 

--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -20,6 +20,8 @@ export const UserSchema = z.object({
   id: z.union([z.string().uuid(), z.number()]).transform(String),
   username: z.string().min(1),
   email: z.string().email(),
+  // Pending (unconfirmed) email change; null/absent when none is in flight.
+  pending_email: z.string().email().nullable().optional(),
   role: z.nativeEnum(Role),
   is_active: z.boolean().optional().default(true),
   last_login: z
@@ -83,6 +85,9 @@ export default class User {
   /** User's email address */
   public email: string;
 
+  /** Pending (unconfirmed) email change, or null if none is in flight */
+  public pending_email: string | null;
+
   /** User's role determining permissions */
   public role: Role;
 
@@ -114,6 +119,7 @@ export default class User {
     this.id = validated.id;
     this.username = validated.username;
     this.email = validated.email;
+    this.pending_email = validated.pending_email ?? null;
     this.role = validated.role;
     this.is_active = validated.is_active;
     this.last_login = validated.last_login
@@ -356,6 +362,7 @@ export default class User {
       id: this.id,
       username: this.username,
       email: this.email,
+      pending_email: this.pending_email,
       role: this.role,
       is_active: this.is_active,
       last_login: this.last_login?.toISOString() || null,

--- a/src/pages/admin/AdminProfileGuarded.svelte
+++ b/src/pages/admin/AdminProfileGuarded.svelte
@@ -7,6 +7,10 @@
 
   let username = "";
   let email = "";
+  // The confirmed address currently stored on the server, plus any pending
+  // (unconfirmed) change still awaiting the email link.
+  let confirmedEmail = "";
+  let pendingEmail: string | null = null;
   let password = "";
   let currentPassword = "";
   let loading = false;
@@ -28,6 +32,8 @@
     if (current) {
       username = current.username;
       email = current.email;
+      confirmedEmail = current.email;
+      pendingEmail = current.pending_email;
     }
     // Load backup status
     try {
@@ -105,21 +111,37 @@
       body.current_password = currentPassword;
     }
 
+    // Remember whether this save requests an email change; the new address
+    // only becomes active after the confirmation link is clicked.
+    const emailChangeRequested = !!body.email && body.email !== confirmedEmail;
+
     const json = await adminPut("/api/admin/users/me", body);
     if (json.success) {
-      message = resetTwofa
-        ? "Profil aktualisiert. 2FA wurde zurückgesetzt – bitte neu einrichten beim nächsten Login."
-        : "Profil gespeichert.";
       password = "";
       currentPassword = "";
       resetTwofa = false;
       // Wenn 2FA reset: ausloggen damit Setup erzwungen wird
       if (body.reset_twofa) {
+        message =
+          "Profil aktualisiert. 2FA wurde zurückgesetzt – bitte neu einrichten beim nächsten Login.";
         await adminAuth.logout();
         window.location.href = "/admin/login";
       } else {
-        // refresh status
+        // Refresh from the server so the form reflects the confirmed state.
         await adminAuth.checkStatus();
+        const updated = get(adminAuthState).user;
+        if (updated) {
+          username = updated.username;
+          confirmedEmail = updated.email;
+          pendingEmail = updated.pending_email;
+          // Keep the input on the confirmed address — a requested change only
+          // takes effect once the link in the confirmation email is clicked.
+          email = updated.email;
+        }
+        message =
+          emailChangeRequested && pendingEmail
+            ? `Profil gespeichert. Wir haben eine Bestätigungs-E-Mail an ${pendingEmail} gesendet – deine E-Mail-Adresse ändert sich erst, nachdem du den Link darin bestätigt hast.`
+            : "Profil gespeichert.";
       }
     } else {
       error = json.message || "Fehler beim Speichern";
@@ -282,9 +304,33 @@
                 autocomplete="email"
               />
             </div>
-            <p class="text-xs text-slate-700 dark:text-smoke-300">
-              Änderungen erfordern Bestätigung über eine E‑Mail.
-            </p>
+            {#if pendingEmail}
+              <p
+                class="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-300"
+              >
+                <svg
+                  class="mt-0.5 h-4 w-4 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  ><path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z"
+                  /></svg
+                >
+                <span>
+                  Ausstehende Änderung auf <strong>{pendingEmail}</strong>.
+                  Bitte bestätige den Link in der E‑Mail. Bis dahin bleibt
+                  <strong>{confirmedEmail}</strong> aktiv.
+                </span>
+              </p>
+            {:else}
+              <p class="text-xs text-slate-700 dark:text-smoke-300">
+                Änderungen erfordern Bestätigung über eine E‑Mail.
+              </p>
+            {/if}
           </div>
           <!-- Password -->
           <div class="space-y-1 md:col-span-2">


### PR DESCRIPTION
> ⚠️ **Gestackt auf #110 (Ticket #108).** Damit dieser Diff sauber bleibt, ist die Basis dieses PRs der Branch `fix/108-profile-csrf` (nicht direkt `dev`). GitHub setzt die Basis automatisch auf `dev`, sobald #110 gemergt ist — **Zielzweig ist also `dev`**. Bitte **#110 zuerst** mergen. (Falls #110 als *Squash* gemergt wird, diesen Branch danach kurz auf `dev` rebasen.)
>
> Inhaltliche Abhängigkeit: Das Speichern einer E-Mail-Änderung (`PUT /users/me`) braucht den CSRF-Fix aus #108, sonst greift der Flow gar nicht.

## Problem

1. Der Bestätigungslink zeigte auf den JSON-Endpunkt `/api/admin/users/confirm-email` → im Browser erschien **rohes JSON** (bzw. eine 400-Fehlerseite). Der Link wirkte „kaputt".
2. Das Profilformular zeigte die **neu getippte** Adresse + Toast „Profil gespeichert" — die Änderung wirkte **schon übernommen**, obwohl server-seitig nur `pending_email` gesetzt wird und die echte Adresse erst nach Bestätigung wechselt.

## Änderung

### Backend
- `UserEmailConfirmController::confirm()` rendert jetzt eine **eigenständige, gestylte HTML-Seite** (Erfolg / ungültig / abgelaufen / fehlgeschlagen) statt JSON. Funktioniert auch ausgeloggt; der Token wird nie an Client-JS weitergereicht.
- **Token-Ablauf (24 h):** abgelaufene Links werden abgewiesen und der hängende `pending_email`-Stand wird aufgeräumt (die Meldung „abgelaufen" stimmt jetzt auch).
- Das bestätigende `UPDATE` ist abgesichert: eine UNIQUE-Kollision (Adresse zwischenzeitlich vergeben) ergibt eine freundliche **409-Seite** statt eines rohen 500.
- `AdminAuth::getCurrentUser()` liefert zusätzlich `pending_email`, sodass `/auth/status`, `/users/me` und die Update-Antwort den ausstehenden Stand kennen.

### Frontend
- `User`-Modell trägt das optionale Feld `pending_email`.
- Die Profilseite hält das E-Mail-Eingabefeld auf der **bestätigten** Adresse, zeigt einen klaren **„Ausstehende Änderung"-Hinweis** und meldet „Bestätigungs-E-Mail gesendet" statt zu suggerieren, die Änderung sei schon aktiv. Der Hinweis bleibt auch nach einem Reload sichtbar.

## Tests / Verifikation
- `php -l` auf den geänderten Backend-Dateien ✓
- `bun run build` ✓ · `bun run test:unit:run` ✓ (6/6 `User`-Tests) · `bun run check`: nur vorbestehende umgebungsbedingte Fehler, keine neuen.
- Manuell zu prüfen: E-Mail ändern → Hinweis „Bestätigung an X gesendet", Feld zeigt weiter alte Adresse; Link in der Mail → freundliche Bestätigungsseite; Login mit neuer Adresse erst danach möglich.

Closes #109