### PR TITLE
Release dev → main: Admin-Profil-Fixes (CSRF, E-Mail-Bestätigungsseite, deutsche Fehlertexte) + carbon-Bump

### DIFF
--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -203,16 +203,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.4",
+            "version": "3.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
+                "reference": "6e7853a668c3107294aff38d42bf760ec02126b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/6e7853a668c3107294aff38d42bf760ec02126b6",
+                "reference": "6e7853a668c3107294aff38d42bf760ec02126b6",
                 "shasum": ""
             },
             "require": {
@@ -304,7 +304,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-07T09:57:54+00:00"
+            "time": "2026-06-14T20:41:42+00:00"
         },
         {
             "name": "phpmailer/phpmailer",

--- a/backend/src/Controllers/UserEmailConfirmController.php
+++ b/backend/src/Controllers/UserEmailConfirmController.php
@@ -4,25 +4,120 @@ declare(strict_types=1);
 
 namespace HypnoseStammtisch\Controllers;
 
+use HypnoseStammtisch\Config\Config;
 use HypnoseStammtisch\Database\Database;
-use HypnoseStammtisch\Utils\Response;
 use HypnoseStammtisch\Utils\AuditLogger;
 
 class UserEmailConfirmController
 {
+    /** Confirmation links stay valid for 24 hours after the change was requested. */
+    private const TOKEN_TTL_SECONDS = 86400;
+
+    /**
+     * Confirm a pending email change.
+     *
+     * This endpoint is opened directly by the user's browser from the link in
+     * the confirmation mail, so it renders a self-contained HTML page instead
+     * of a JSON API response (the previous behaviour showed raw JSON, which
+     * looked like the link was broken).
+     */
     public static function confirm(string $token): void
     {
-        if (!$token) {
-            Response::error('Invalid token', 400);
+        if ($token === '') {
+            self::renderPage(400, false, 'Ungültiger Link', 'Der Bestätigungslink ist unvollständig.');
             return;
         }
-        $row = Database::fetchOne('SELECT id, pending_email FROM users WHERE email_change_token = ? AND pending_email IS NOT NULL', [$token]);
+
+        // Read "now" from the database in the same query so the TTL comparison
+        // is independent of the PHP timezone: both timestamps come from the DB
+        // clock, so any DB<->PHP offset cancels out.
+        $row = Database::fetchOne(
+            'SELECT id, pending_email, email_change_requested_at, CURRENT_TIMESTAMP AS db_now
+             FROM users WHERE email_change_token = ? AND pending_email IS NOT NULL',
+            [$token]
+        );
+
         if (!$row) {
-            Response::error('Token ungültig oder abgelaufen', 400);
+            self::renderPage(400, false, 'Link ungültig', 'Dieser Bestätigungslink ist ungültig oder wurde bereits verwendet.');
             return;
         }
-        Database::execute('UPDATE users SET email = pending_email, pending_email = NULL, email_change_token = NULL, email_change_requested_at = NULL WHERE id = ?', [$row['id']]);
+
+        // Reject (and clean up) links whose request is older than the TTL.
+        $requestedAt = $row['email_change_requested_at'] ?? null;
+        $dbNow = $row['db_now'] ?? null;
+        if ($requestedAt !== null && $dbNow !== null) {
+            $requestedTs = strtotime((string)$requestedAt);
+            $nowTs = strtotime((string)$dbNow);
+            if ($requestedTs !== false && $nowTs !== false && ($nowTs - $requestedTs) > self::TOKEN_TTL_SECONDS) {
+                Database::execute(
+                    'UPDATE users SET pending_email = NULL, email_change_token = NULL, email_change_requested_at = NULL WHERE id = ?',
+                    [$row['id']]
+                );
+                AuditLogger::log('user.email_change_expired', 'user', (string)$row['id']);
+                self::renderPage(400, false, 'Link abgelaufen', 'Dieser Bestätigungslink ist abgelaufen. Bitte fordere die E-Mail-Änderung erneut an.');
+                return;
+            }
+        }
+
+        try {
+            Database::execute(
+                'UPDATE users SET email = pending_email, pending_email = NULL, email_change_token = NULL, email_change_requested_at = NULL WHERE id = ?',
+                [$row['id']]
+            );
+        } catch (\Throwable $e) {
+            // Most likely a UNIQUE violation because the address was taken in
+            // the meantime. Keep the pending change so the user can retry and
+            // still show a friendly page instead of a raw 500.
+            error_log('Email change confirmation failed: ' . $e->getMessage());
+            self::renderPage(409, false, 'Bestätigung fehlgeschlagen', 'Die E-Mail-Adresse konnte nicht bestätigt werden. Möglicherweise wird sie bereits von einem anderen Konto verwendet.');
+            return;
+        }
+
         AuditLogger::log('user.email_confirmed', 'user', (string)$row['id']);
-        Response::success(['email_confirmed' => true], 'E-Mail erfolgreich bestätigt');
+
+        self::renderPage(200, true, 'E-Mail bestätigt', 'Deine neue E-Mail-Adresse wurde erfolgreich bestätigt. Du kannst dich jetzt mit ihr anmelden.');
+    }
+
+    /**
+     * Render a minimal, self-contained confirmation result page.
+     */
+    private static function renderPage(int $status, bool $success, string $heading, string $message): void
+    {
+        if (!headers_sent()) {
+            http_response_code($status);
+            header('Content-Type: text/html; charset=utf-8');
+            header('Cache-Control: no-cache, no-store, must-revalidate');
+        }
+
+        $appName = htmlspecialchars(Config::getAppName(), ENT_QUOTES, 'UTF-8');
+        $heading = htmlspecialchars($heading, ENT_QUOTES, 'UTF-8');
+        $message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+        $loginUrl = htmlspecialchars(
+            rtrim((string)Config::get('app.url', ''), '/') . '/#/admin/login',
+            ENT_QUOTES,
+            'UTF-8'
+        );
+        $accent = $success ? '#16a34a' : '#dc2626';
+        $icon = $success ? '✓' : '✕';
+
+        echo <<<HTML
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{$heading} – {$appName}</title>
+</head>
+<body style="font-family: Arial, sans-serif; background:#f4f4f4; color:#333; margin:0; padding:40px 20px;">
+  <div style="max-width:520px; margin:0 auto; background:#fff; border-radius:8px; padding:32px; box-shadow:0 1px 4px rgba(0,0,0,.08); text-align:center;">
+    <div style="width:56px; height:56px; line-height:56px; margin:0 auto 16px; border-radius:50%; background:{$accent}; color:#fff; font-size:28px;">{$icon}</div>
+    <h1 style="margin:0 0 12px; font-size:22px; color:{$accent};">{$heading}</h1>
+    <p style="margin:0 0 24px; line-height:1.6;">{$message}</p>
+    <a href="{$loginUrl}" style="display:inline-block; background:#5a67d8; color:#fff; padding:12px 28px; border-radius:6px; text-decoration:none;">Zum Admin-Login</a>
+  </div>
+  <p style="text-align:center; color:#999; font-size:12px; margin-top:24px;">© {$appName}</p>
+</body>
+</html>
+HTML;
     }
 }

--- a/backend/src/Middleware/AdminAuth.php
+++ b/backend/src/Middleware/AdminAuth.php
@@ -88,7 +88,7 @@ class AdminAuth
             return null;
         }
 
-        $sql = "SELECT id, username, email, role, is_active, last_login, created_at, updated_at
+        $sql = "SELECT id, username, email, pending_email, role, is_active, last_login, created_at, updated_at
             FROM users WHERE id = ? AND is_active = 1";
         $user = Database::fetchOne($sql, [$_SESSION['admin_user_id']]);
 

--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -20,6 +20,8 @@ export const UserSchema = z.object({
   id: z.union([z.string().uuid(), z.number()]).transform(String),
   username: z.string().min(1),
   email: z.string().email(),
+  // Pending (unconfirmed) email change; null/absent when none is in flight.
+  pending_email: z.string().email().nullable().optional(),
   role: z.nativeEnum(Role),
   is_active: z.boolean().optional().default(true),
   last_login: z
@@ -83,6 +85,9 @@ export default class User {
   /** User's email address */
   public email: string;
 
+  /** Pending (unconfirmed) email change, or null if none is in flight */
+  public pending_email: string | null;
+
   /** User's role determining permissions */
   public role: Role;
 
@@ -114,6 +119,7 @@ export default class User {
     this.id = validated.id;
     this.username = validated.username;
     this.email = validated.email;
+    this.pending_email = validated.pending_email ?? null;
     this.role = validated.role;
     this.is_active = validated.is_active;
     this.last_login = validated.last_login
@@ -356,6 +362,7 @@ export default class User {
       id: this.id,
       username: this.username,
       email: this.email,
+      pending_email: this.pending_email,
       role: this.role,
       is_active: this.is_active,
       last_login: this.last_login?.toISOString() || null,

--- a/src/pages/admin/AdminProfileGuarded.svelte
+++ b/src/pages/admin/AdminProfileGuarded.svelte
@@ -3,9 +3,14 @@
   import { get } from "svelte/store";
   import AdminLayout from "../../components/admin/AdminLayout.svelte";
   import { adminAuth, adminAuthState } from "../../stores/admin";
+  import { adminGet, adminPost, adminPut } from "../../utils/adminApi";
 
   let username = "";
   let email = "";
+  // The confirmed address currently stored on the server, plus any pending
+  // (unconfirmed) change still awaiting the email link.
+  let confirmedEmail = "";
+  let pendingEmail: string | null = null;
   let password = "";
   let currentPassword = "";
   let loading = false;
@@ -27,15 +32,16 @@
     if (current) {
       username = current.username;
       email = current.email;
+      confirmedEmail = current.email;
+      pendingEmail = current.pending_email;
     }
     // Load backup status
     try {
-      const r = await fetch("/api/admin/auth/2fa/backup-codes/status", {
-        credentials: "include",
-      });
-      if (r.ok) {
-        const j = await r.json();
-        if (j.success) backupRemaining = j.data.remaining;
+      const result = await adminGet<{ remaining: number }>(
+        "/api/admin/auth/2fa/backup-codes/status",
+      );
+      if (result.success && result.data) {
+        backupRemaining = result.data.remaining;
       }
     } catch {
       /* ignore */
@@ -61,16 +67,14 @@
     error = "";
     message = "";
     try {
-      const r = await fetch("/api/admin/auth/2fa/backup-codes/generate", {
-        method: "POST",
-        credentials: "include",
-      });
-      const j = await r.json();
-      if (j.success) {
+      const result = await adminPost<{ codes: string[] }>(
+        "/api/admin/auth/2fa/backup-codes/generate",
+      );
+      if (result.success && result.data) {
         message = "Neue Backup-Codes generiert. Alte wurden ungültig.";
-        backupRemaining = j.data.codes.length;
+        backupRemaining = result.data.codes.length;
         // optional: anzeigen / download
-        const blob = new Blob([j.data.codes.join("\n")], {
+        const blob = new Blob([result.data.codes.join("\n")], {
           type: "text/plain",
         });
         const url = URL.createObjectURL(blob);
@@ -80,7 +84,7 @@
         a.click();
         URL.revokeObjectURL(url);
       } else {
-        error = j.message || "Fehler beim Generieren";
+        error = result.message || "Fehler beim Generieren";
       }
     } catch {
       error = "Netzwerkfehler";
@@ -107,27 +111,37 @@
       body.current_password = currentPassword;
     }
 
-    const res = await fetch("/api/admin/users/me", {
-      method: "PUT",
-      credentials: "include",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    const json = await res.json();
+    // Remember whether this save requests an email change; the new address
+    // only becomes active after the confirmation link is clicked.
+    const emailChangeRequested = !!body.email && body.email !== confirmedEmail;
+
+    const json = await adminPut("/api/admin/users/me", body);
     if (json.success) {
-      message = resetTwofa
-        ? "Profil aktualisiert. 2FA wurde zurückgesetzt – bitte neu einrichten beim nächsten Login."
-        : "Profil gespeichert.";
       password = "";
       currentPassword = "";
       resetTwofa = false;
       // Wenn 2FA reset: ausloggen damit Setup erzwungen wird
       if (body.reset_twofa) {
+        message =
+          "Profil aktualisiert. 2FA wurde zurückgesetzt – bitte neu einrichten beim nächsten Login.";
         await adminAuth.logout();
         window.location.href = "/admin/login";
       } else {
-        // refresh status
+        // Refresh from the server so the form reflects the confirmed state.
         await adminAuth.checkStatus();
+        const updated = get(adminAuthState).user;
+        if (updated) {
+          username = updated.username;
+          confirmedEmail = updated.email;
+          pendingEmail = updated.pending_email;
+          // Keep the input on the confirmed address — a requested change only
+          // takes effect once the link in the confirmation email is clicked.
+          email = updated.email;
+        }
+        message =
+          emailChangeRequested && pendingEmail
+            ? `Profil gespeichert. Wir haben eine Bestätigungs-E-Mail an ${pendingEmail} gesendet – deine E-Mail-Adresse ändert sich erst, nachdem du den Link darin bestätigt hast.`
+            : "Profil gespeichert.";
       }
     } else {
       error = json.message || "Fehler beim Speichern";
@@ -290,9 +304,33 @@
                 autocomplete="email"
               />
             </div>
-            <p class="text-xs text-slate-700 dark:text-smoke-300">
-              Änderungen erfordern Bestätigung über eine E‑Mail.
-            </p>
+            {#if pendingEmail}
+              <p
+                class="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-300"
+              >
+                <svg
+                  class="mt-0.5 h-4 w-4 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  ><path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z"
+                  /></svg
+                >
+                <span>
+                  Ausstehende Änderung auf <strong>{pendingEmail}</strong>.
+                  Bitte bestätige den Link in der E‑Mail. Bis dahin bleibt
+                  <strong>{confirmedEmail}</strong> aktiv.
+                </span>
+              </p>
+            {:else}
+              <p class="text-xs text-slate-700 dark:text-smoke-300">
+                Änderungen erfordern Bestätigung über eine E‑Mail.
+              </p>
+            {/if}
           </div>
           <!-- Password -->
           <div class="space-y-1 md:col-span-2">

--- a/src/utils/adminApi.ts
+++ b/src/utils/adminApi.ts
@@ -114,7 +114,7 @@ export async function adminApi<T = unknown>(
       console.error("Failed to get CSRF token:", error);
       return {
         success: false,
-        message: "Security token error. Please refresh the page.",
+        message: "Sicherheitstoken-Fehler. Bitte lade die Seite neu.",
       };
     }
   }
@@ -175,13 +175,12 @@ export async function adminApi<T = unknown>(
 
     return (await response.json()) as AdminApiResponse<T>;
   } catch (error) {
+    // The technical error (e.g. "Failed to fetch") is kept in the console for
+    // debugging; the user-facing message stays German like the rest of the UI.
     console.error("Admin API error:", error);
     return {
       success: false,
-      message:
-        error instanceof Error
-          ? error.message
-          : "Network error. Please try again.",
+      message: "Netzwerkfehler. Bitte versuche es erneut.",
     };
   }
 }


### PR DESCRIPTION
## Überblick

Promotion von `dev` → `main` (löst den **prod**-Deploy aus: GitHub Actions `Build and Deploy to SFTP` → `composer install --no-dev` + Frontend-Build + SFTP-Upload von `dist/`). Enthält **2 Commits**: ein gebündelter Admin-Fix-PR (#110, der seinerseits #108 und #109/#111 enthält) sowie einen Backend-Dependency-Bump.

> ✅ **Kein DB-Migrationsschritt nötig.** Anders als beim letzten Release (#100, Migration 012) ändert dieser Release **kein** Schema. Alle vom E-Mail-Bestätigungs-Fix genutzten Spalten (`pending_email`, `email_change_token`, `email_change_requested_at`) existieren bereits seit `001_initial_schema.sql` auf prod. Der carbon-Bump wird automatisch über `composer install` im CI-Build eingespielt. → Der Merge ist self-contained; nach dem Deploy ist nur eine Funktionsprüfung nötig.

## Funktionale Änderungen

Der Squash-Commit `ffee1ec` (#110) bündelt drei logische Admin-Fixes:

| PR | Inhalt |
|---|---|
| #108 | **Profil speichern schlug fehl (403 CSRF).** Die Profilseite setzte rohe `fetch()`-Calls für `PUT /api/admin/users/me` ohne `X-CSRF-Token`-Header ab → `AdminAuth::requireCSRF()` lehnte mit „Invalid or missing CSRF token" ab, das Profil ließ sich nie speichern. Speichern läuft jetzt über den `adminPut()`-Helper (holt das Token, hängt den Header an, retry-t einmal bei 403-CSRF). Konsistenz: die Backup-Code Status/Generate-Calls derselben Seite nutzen jetzt ebenfalls `adminGet()`/`adminPost()` — die letzten rohen `fetch()`-Calls der Profilseite sind damit weg. *Fixes #108* |
| #110 (Review) | **Admin-API-Fehlermeldungen deutsch halten.** `adminApi()` lieferte englische Fallbacks („Network error. Please try again.", rohes „Failed to fetch", „Security token error…") direkt in die deutsche Admin-UI (u. a. Profil-Speichern / Backup-Codes). Die beiden user-sichtbaren Fallbacks sind jetzt lokalisiert; der technische Fehler bleibt für Debugging in der Konsole. |
| #109 / #111 | **E-Mail-Änderung: echte Bestätigungsseite + Ausstehend-Status.** Der Bestätigungslink zeigte vorher rohes JSON (sah kaputt aus); zugleich suggerierte das Formular per „Profil gespeichert", die Änderung sei schon aktiv. **Backend:** `UserEmailConfirmController::confirm()` rendert jetzt eine self-contained, gestylte HTML-Ergebnisseite (Erfolg / ungültig / abgelaufen / fehlgeschlagen) statt JSON, erzwingt eine **24h-Token-TTL** (räumt abgelaufene Pending-Changes auf) und fängt eine UNIQUE-Kollision als freundliche **409**-Seite statt rohem 500 ab. Die TTL vergleicht `CURRENT_TIMESTAMP` aus derselben Query, ist also **zeitzonen-robust** (PHP↔DB-Offset hebt sich auf). `AdminAuth::getCurrentUser()` selektiert zusätzlich `pending_email`, sodass `/auth/status`, `/users/me` und die Profil-Update-Antwort die laufende Änderung ausweisen. **Frontend:** das `User`-Model trägt das optionale `pending_email`-Feld; die Profilseite hält das Eingabefeld auf der **bestätigten** Adresse, zeigt ein „Ausstehende Änderung"-Banner und meldet „Bestätigungs-E-Mail gesendet" statt zu implizieren, die Änderung sei schon wirksam. *Fixes #109* |

## Dependency-Updates (Dependabot)

| Commit | Update |
|---|---|
| `6e7c293` | **`nesbot/carbon` 3.11.4 → 3.12.3** (Backend, semver-minor, Gruppe `backend-minor-and-patch`). Nur `composer.lock` betroffen; wird beim prod-Build automatisch via `composer install --no-dev --optimize-autoloader` installiert und nach `dist/vendor/` kopiert. |

> ℹ️ Der offene Dependabot-PR **#107** (`bump nesbot/carbon … 3.11.4 → 3.12.3`) ist durch diesen Commit inhaltlich erledigt und kann nach dem Merge als „superseded" geschlossen werden.

## Verifikation

- ✅ Beta (`dev`) ist mit diesem Stand deployt — Push von `ffee1ec` → `Build and Deploy to SFTP` **grün** (Run `27632986684`).
- ✅ carbon-Bump-Build (`6e7c293`) **grün**; `Migrations Smoke Test` (MariaDB) **grün**.
- ✅ Kein Schema-Diff: alle genutzten `email_change_*`/`pending_email`-Spalten existieren bereits in `001_initial_schema.sql` auf `main`.
- ✅ Diff umfasst nur 6 Dateien (Backend-Controller/Middleware, `composer.lock`, `User.ts`, `adminApi.ts`, `AdminProfileGuarded.svelte`) — keine Migrationen.

---

## ⚠️ Manuelle Schritte nach dem Merge (PROD)

> Der Merge nach `main` startet **automatisch** den prod-Deploy (composer install + Build + SFTP-Upload). Es gibt **keine** DB-Migration und **keinen** Composer-Schritt von Hand.

1. **DB-Migration:** ❌ **nicht nötig** — dieser Release ändert kein Schema.
2. **Composer/Backend-Deps:** ❌ **nicht von Hand** — der carbon-Bump kommt automatisch über den CI-Build (`composer.lock` ist eingecheckt).
3. **Funktionsprüfung nach Deploy:**
   - Admin-Backend → **Profil speichern** (Benutzername/Passwort) funktioniert wieder (kein 403 CSRF).
   - **E-Mail-Adresse ändern:** Formular zeigt „Bestätigungs-E-Mail gesendet" + „Ausstehende Änderung"-Banner; das Eingabefeld bleibt auf der alten Adresse.
   - **Bestätigungslink** aus der Mail öffnen → gestylte HTML-Erfolgsseite (kein rohes JSON); danach ist die neue Adresse aktiv. Abgelaufener/ungültiger Link → freundliche Fehlerseite.
4. **Caching:** Falls vor Frontend/API ein CDN- oder Browser-Cache greift, nach dem Deploy invalidieren.
5. **Aufräumen:** Dependabot-PR **#107** als „superseded" schließen (Inhalt ist mit `6e7c293` bereits auf `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
