### PR TITLE
fix(admin): Notification-Toasts blockieren Logout-Button nicht mehr (#113)

### DIFF
--- a/src/components/admin/AdminNotifications.svelte
+++ b/src/components/admin/AdminNotifications.svelte
@@ -74,8 +74,10 @@
   }
 
   function getNotificationClasses(type: string): string {
+    // pointer-events-auto re-enables clicks on the toast itself; the container
+    // is pointer-events-none so its transparent area never blocks the UI.
     const baseClasses =
-      "p-4 rounded-lg shadow-lg border-l-4 transition-all duration-300 ease-in-out";
+      "pointer-events-auto p-4 rounded-lg shadow-lg border-l-4 transition-all duration-300 ease-in-out";
 
     switch (type) {
       case "success":
@@ -108,8 +110,15 @@
 </script>
 
 <!-- Admin Notification Container -->
+<!--
+  Anchored bottom-right (away from the top header) and pointer-events-none so
+  the toast stack can never overlap or block header controls such as the logout
+  button — even while a semi-transparent notification is visible. See #113.
+-->
 {#if adminNotifications.length > 0}
-  <div class="fixed top-4 right-4 z-50 space-y-2 max-w-sm">
+  <div
+    class="pointer-events-none fixed bottom-4 right-4 z-50 space-y-2 max-w-sm"
+  >
     {#each adminNotifications as notification (notification.id)}
       <div
         class={getNotificationClasses(notification.type)}


### PR DESCRIPTION
## Problem

Behebt #113: Im Admin-Bereich blockierte eine „unsichtbare" Box den **Abmelden**-Button.

Ursache: Die Admin-Benachrichtigungs-Toasts wurden in einem Container mit `fixed top-4 right-4 z-50` gerendert — also in **derselben** Ecke oben rechts wie der „Abmelden"-Button im Header ([AdminLayout.svelte:310-315](../blob/dev/src/components/admin/AdminLayout.svelte#L310-L315)). Solange ein Toast sichtbar war, lag er über dem Button und fing den Klick ab. Im Dark-Mode ist der Toast-Hintergrund halbtransparent (`dark:bg-*-900/30`) — die Box wirkte dadurch „unsichtbar", blockierte den Button aber trotzdem.

## Lösung

- **Toast-Stack nach unten rechts verlegt** (`fixed bottom-4 right-4`). Damit liegt er an keiner Scroll-Position mehr über dem oberen Header / Logout-Button — ohne auf Header-Höhen angewiesen zu sein.
- **`pointer-events-none`** auf dem Container, **`pointer-events-auto`** auf jedem Toast: die transparente Fläche des Containers (inkl. der `space-y-2`-Lücken zwischen mehreren Toasts) fängt keine Klicks mehr ab, der Toast selbst bleibt aber interaktiv (Schließen-Button).

Reine CSS-Klassen-Änderung in einer Datei; kein Verhaltens-/Logik-Eingriff.

## Verifikation

- ✅ `bun run build:frontend` läuft fehlerfrei durch.
- ✅ Manuell zu prüfen: Im Admin-Bereich eine Aktion auslösen, die einen Toast erzeugt → der „Abmelden"-Button bleibt während der Toast-Anzeige klick- und sichtbar; Toast erscheint unten rechts.

## Scope

Eigenständiger Fix, Ziel-Branch `dev`. Nicht Teil des laufenden Release-PRs #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
