### PR TITLE
fix(admin): Fehlgeschlagenen Versand der E-Mail-Bestätigung erkennen (#114)

### DIFF
--- a/backend/src/Controllers/UserController.php
+++ b/backend/src/Controllers/UserController.php
@@ -88,13 +88,18 @@ class UserController
         if (isset($input['email']) && $input['email'] !== $current['email']) {
             // create pending email change with token
             $token = self::generateSecureToken();
+            // Send the confirmation first: if it cannot be delivered, don't
+            // record a pending change the user could never confirm — surface an
+            // honest error instead of a misleading success.
+            if (!self::sendEmailChangeConfirmation($current['email'], $input['email'], $token)) {
+                Response::error('Die Bestätigungs-E-Mail konnte nicht gesendet werden. Bitte versuche es später erneut.', 502);
+                return;
+            }
             $fields[] = 'pending_email = ?';
             $params[] = $input['email'];
             $fields[] = 'email_change_token = ?';
             $params[] = $token;
             $fields[] = 'email_change_requested_at = CURRENT_TIMESTAMP';
-            // send confirmation email
-            self::sendEmailChangeConfirmation($current['email'], $input['email'], $token);
         }
         if (!empty($input['password'])) {
             $fields[] = 'password_hash = ?';
@@ -170,13 +175,17 @@ class UserController
             if (isset($input[$f])) {
                 if ($f === 'email') {
                     $token = self::generateSecureToken();
+                    // Send the confirmation first; abort without recording a
+                    // pending change if it cannot be delivered (see updateMe()).
+                    if (!self::sendEmailChangeConfirmation(null, $input[$f], $token)) {
+                        Response::error('Die Bestätigungs-E-Mail konnte nicht gesendet werden. Bitte versuche es später erneut.', 502);
+                        return;
+                    }
                     $fields[] = 'pending_email = ?';
                     $params[] = $input[$f];
                     $fields[] = 'email_change_token = ?';
                     $params[] = $token;
                     $fields[] = 'email_change_requested_at = CURRENT_TIMESTAMP';
-                    // send confirmation to new email only
-                    self::sendEmailChangeConfirmation(null, $input[$f], $token);
                 } else {
                     $fields[] = "$f = ?";
                     $params[] = $input[$f];
@@ -213,9 +222,9 @@ class UserController
         Response::success(['updated' => true, 'user' => $user], 'User updated');
     }
 
-    private static function sendEmailChangeConfirmation(?string $oldEmail, string $newEmail, string $token): void
+    private static function sendEmailChangeConfirmation(?string $oldEmail, string $newEmail, string $token): bool
     {
-        EmailService::sendEmailChangeConfirmation($oldEmail, $newEmail, $token);
+        return EmailService::sendEmailChangeConfirmation($oldEmail, $newEmail, $token);
     }
 
     private static function generateSecureToken(): string


### PR DESCRIPTION
## Problem

Behebt #114: Schlug der Versand der Bestätigungs-E-Mail bei einer E-Mail-Änderung fehl, wurde der Fehler **nicht erkannt**.

Der Wrapper `UserController::sendEmailChangeConfirmation()` war `void` und verwarf den `bool`-Rückgabewert von `EmailService::sendEmailChangeConfirmation()`. Bei einem SMTP-Fehler wurde trotzdem:
- `pending_email` / `email_change_token` / `email_change_requested_at` in die DB geschrieben und
- `success = true` an das Frontend zurückgegeben.

Folge: Der Nutzer sah „Bestätigungs-E-Mail gesendet" + „Ausstehende Änderung"-Banner, erhielt aber nie eine Mail und konnte die Änderung **nie bestätigen** — sie hing dauerhaft fest.

## Lösung

- Die Bestätigungs-E-Mail wird jetzt **vor** dem Schreiben der Pending-Felder versendet — in `updateMe()` ([Self-Service](../blob/dev/backend/src/Controllers/UserController.php#L88)) und `adminUpdateUser()` ([Head-Admin ändert fremde Adresse](../blob/dev/backend/src/Controllers/UserController.php#L171)).
- Schlägt der Versand fehl, wird ein ehrlicher **502** zurückgegeben und **nichts** persistiert (atomar — das `UPDATE` läuft erst danach). Der Nutzer kann es erneut versuchen, statt in einem nicht bestätigbaren Pending-Zustand zu landen.
- Der Wrapper gibt jetzt `bool` zurück und reicht das Ergebnis durch.

`EmailService::sendEmailChangeConfirmation()` fängt Exceptions selbst ab und liefert `false` ([Zeile 330-336](../blob/dev/backend/src/Utils/EmailService.php#L330-L336)) — das Guard wirft also nicht.

## Verifikation

- ✅ `php -l backend/src/Controllers/UserController.php` — keine Syntaxfehler.
- ✅ Bestehender Test `tests/validate_password_reset.php` bleibt grün (prüft, dass `UserController` weiterhin `EmailService::sendEmailChangeConfirmation` verwendet — tut es).
- Manuell zu prüfen: SMTP absichtlich fehlschlagen lassen → Profil-Speichern mit E-Mail-Änderung zeigt jetzt eine Fehlermeldung, und es entsteht **kein** hängender Pending-Eintrag.

## Scope

Eigenständiger Backend-Fix, Ziel-Branch `dev`. Vorbestehender Bug, nicht Teil des Release-PRs #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
