### PR TITLE
fix(admin): pending_email auch nach 2FA-Login ausliefern

### DIFF
--- a/backend/src/Middleware/AdminAuth.php
+++ b/backend/src/Middleware/AdminAuth.php
@@ -244,6 +244,7 @@ class AdminAuth
                 'id' => $user['id'],
                 'username' => $user['username'],
                 'email' => $user['email'],
+                'pending_email' => $user['pending_email'] ?? null,
                 'role' => $user['role'],
                 'is_active' => (bool)$user['is_active'],
                 'last_login' => $user['last_login'],

--- a/backend/src/Middleware/AdminAuth.php
+++ b/backend/src/Middleware/AdminAuth.php
@@ -220,7 +220,7 @@ class AdminAuth
     {
         // Ensure string for DB layer (Prepared Statements akzeptieren beides, wir normalisieren dennoch)
         $idParam = (string)$userId;
-        $sql = "SELECT id, username, email, role, is_active, last_login, created_at, updated_at, twofa_enabled FROM users WHERE id = ?";
+        $sql = "SELECT id, username, email, pending_email, role, is_active, last_login, created_at, updated_at, twofa_enabled FROM users WHERE id = ?";
         $user = Database::fetchOne($sql, [$idParam]);
 
         if (!$user) {


### PR DESCRIPTION
## Hintergrund

Folge-Fix aus der Code-Review zu Release-PR #112 (Befund #1).

Release #112 hat `pending_email` zu `AdminAuth::getCurrentUser()` hinzugefügt, damit die Profilseite das „Ausstehende E-Mail-Änderung"-Banner anzeigen kann. Die **Schwester-Query** in `finalizeTwoFactor()` (läuft beim Abschluss eines 2FA-Logins) wurde dabei **nicht** angepasst:

- [`getCurrentUser()`](../blob/dev/backend/src/Middleware/AdminAuth.php#L91) selektiert `pending_email` ✅
- [`finalizeTwoFactor()`](../blob/dev/backend/src/Middleware/AdminAuth.php#L223) selektierte es nicht ❌

Dadurch fehlte `pending_email` im User-Objekt direkt nach einem 2FA-Login, bis der nächste `/auth/status`-Refresh es nachlud.

## Lösung

`pending_email` in die `SELECT`-Liste von `finalizeTwoFactor()` aufgenommen — beide Pfade liefern jetzt eine konsistente User-Form.

## Impact / Verifikation

- Geringe Auswirkung: die Profilseite ruft beim Mount ohnehin `checkStatus()` → `getCurrentUser()` auf, das Banner erschien also trotzdem. Dieser Fix schließt die Inkonsistenz an der Quelle.
- ✅ `php -l backend/src/Middleware/AdminAuth.php` — keine Syntaxfehler.
- 1-Zeilen-Änderung, kein Logik-/Verhaltens-Eingriff.

## Scope

Kein eigenes Issue (Review-Befund). Ziel-Branch `dev`. Unabhängig von #112, #115, #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
