### PR TITLE
fix(admin): Zeit-/Datums-Picker auf Mobile über dem Event-Modal anzeigen (#118)

### DIFF
--- a/src/components/forms/DatePicker.svelte
+++ b/src/components/forms/DatePicker.svelte
@@ -295,7 +295,7 @@
     <Portal>
       {#if isMobile}
         <div
-          class="fixed inset-0 bg-black/50 z-40 animate-fade-in"
+          class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"
           on:click={close}
           on:keydown={(e) => e.key === "Escape" && close()}
           role="button"
@@ -309,7 +309,7 @@
         aria-label="Datum auswählen"
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
-          ? 'fixed inset-x-0 bottom-0 z-50 max-h-[85vh] overflow-y-auto rounded-t-2xl'
+          ? 'fixed inset-x-0 bottom-0 z-[10050] max-h-[85vh] overflow-y-auto rounded-t-2xl'
           : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[300px]"
         style={isMobile ? undefined : pickerStyle}
       >

--- a/src/components/forms/DateTimePicker.svelte
+++ b/src/components/forms/DateTimePicker.svelte
@@ -417,7 +417,7 @@
     <Portal>
       {#if isMobile}
         <div
-          class="fixed inset-0 bg-black/50 z-40 animate-fade-in"
+          class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"
           on:click={close}
           on:keydown={(e) => e.key === "Escape" && close()}
           role="button"
@@ -431,7 +431,7 @@
         aria-label="Datum und Zeit auswählen"
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
-          ? 'fixed inset-x-0 bottom-0 z-50 max-h-[90vh] overflow-y-auto rounded-t-2xl'
+          ? 'fixed inset-x-0 bottom-0 z-[10050] max-h-[90vh] overflow-y-auto rounded-t-2xl'
           : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[320px]"
         style={isMobile ? undefined : pickerStyle}
       >

--- a/src/components/forms/TimePicker.svelte
+++ b/src/components/forms/TimePicker.svelte
@@ -263,7 +263,7 @@
     <Portal>
       {#if isMobile}
         <div
-          class="fixed inset-0 bg-black/50 z-40 animate-fade-in"
+          class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"
           on:click={close}
           on:keydown={(e) => e.key === "Escape" && close()}
           role="button"
@@ -277,7 +277,7 @@
         aria-label="Uhrzeit auswählen"
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
-          ? 'fixed inset-x-0 bottom-0 z-50 rounded-t-2xl'
+          ? 'fixed inset-x-0 bottom-0 z-[10050] rounded-t-2xl'
           : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[280px]"
         style={isMobile ? undefined : pickerStyle}
       >


### PR DESCRIPTION
## Problem

Behebt #118. Auf Mobilgeräten (gemeldet: **iPhone 15 Pro**) ließ sich im Event-Modal der **Zeit-Picker scheinbar nicht öffnen**.

Die ursprüngliche „Entwurf"-Vermutung im Issue war ein Nebeneffekt der Reproduktion: Der Bug ist **mobil + modal**-spezifisch, **nicht** status-abhängig. Frontend-Validierung, Backend-`required` und das DB-Schema verlangen Zeiten unabhängig vom Status — Zeiten lassen sich in jedem Codepfad setzen.

## Ursache

Im mobilen Bottom-Sheet-Modus rendern `DateTimePicker`, `TimePicker` und `DatePicker` ihr Popup mit **`z-50`** (Backdrop `z-40`). Das Event-Erstellen/-Bearbeiten-Modal liegt aber bei **`z-[9999]`** ([AdminEvents.svelte:726](../blob/dev/src/pages/admin/AdminEvents.svelte#L726)).

→ Der Picker öffnete zwar (`isOpen = true`), wurde aber **hinter** dem Modal gerendert und war unsichtbar/nicht bedienbar. Da Mobile zusätzlich den Body-Scroll sperrt, wirkte es, als würde gar nichts passieren.

Am **Desktop** nutzt der Picker `z-[10050]` (über dem Modal) — deshalb trat der Bug dort nicht auf, was die „funktioniert am Desktop, nicht am iPhone"-Beobachtung erklärt.

## Lösung

Das mobile Popup wird über das Modal gehoben — konsistent mit dem Desktop-Wert:

| Element | vorher | nachher |
|---|---|---|
| Dialog (mobil) | `z-50` | `z-[10050]` |
| Backdrop (mobil) | `z-40` | `z-[10040]` |

Backdrop (10040) > Modal (9999) → dimmt das Modal; Dialog (10050) > Backdrop → liegt obenauf. Reine z-index-Klassenänderung in den drei Picker-Komponenten — kein Logik-/Verhaltenseingriff.

## Verifikation

- ✅ `bun run build:frontend` — fehlerfrei.
- Manuell zu prüfen (mobiles Viewport / iPhone): Admin → Events → neues/Entwurf-Event → Tab „Zeit" → Picker tippen. Der Picker erscheint jetzt als Bottom-Sheet **über** dem Modal; Start-/Endzeit lassen sich setzen und übernehmen.

## Scope

Eigenständiger Frontend-Fix, Ziel-Branch `dev`. Unabhängig von #115/#116/#117/#120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
