### PR TITLE
Release dev → main: Toast-Fix, E-Mail-Fail-Fast, Pending-Email 2FA, Picker z-index, Convention+Party

### DIFF
--- a/backend/migrations/013_add_event_categories_convention_party.sql
+++ b/backend/migrations/013_add_event_categories_convention_party.sql
@@ -1,0 +1,22 @@
+-- Migration 013: Add 'convention' and 'party' to the event category ENUMs
+--
+-- Extends the category ENUM on both `events.category` and
+-- `event_series.default_category` so events can be categorised as conventions
+-- ("Convention") and parties — see GitHub issue #119.
+--
+-- MODIFY COLUMN re-declares the full ENUM definition. This is idempotent
+-- (re-running sets the same definition) and preserves all existing rows, since
+-- every prior value remains part of the ENUM. Both tables are created in
+-- migration 001, so they always exist by the time this runs — no
+-- information_schema guard is needed. Forward-only; no result set is produced,
+-- so the runner's PDO::exec() path stays clean (see migrations/README + 008).
+
+ALTER TABLE events
+  MODIFY COLUMN category
+  ENUM('workshop','stammtisch','practice','lecture','special','convention','party')
+  DEFAULT 'stammtisch';
+
+ALTER TABLE event_series
+  MODIFY COLUMN default_category
+  ENUM('workshop','stammtisch','practice','lecture','special','convention','party')
+  DEFAULT 'stammtisch';

--- a/backend/src/Controllers/FormController.php
+++ b/backend/src/Controllers/FormController.php
@@ -323,7 +323,7 @@ class FormController
         }
 
         // Category validation
-        if (!empty($data['category']) && !in_array($data['category'], ['workshop', 'stammtisch', 'practice', 'lecture', 'special'])) {
+        if (!empty($data['category']) && !in_array($data['category'], ['workshop', 'stammtisch', 'practice', 'lecture', 'special', 'convention', 'party'])) {
             $errors[] = 'Invalid event category';
         }
 

--- a/backend/src/Controllers/UserController.php
+++ b/backend/src/Controllers/UserController.php
@@ -88,13 +88,18 @@ class UserController
         if (isset($input['email']) && $input['email'] !== $current['email']) {
             // create pending email change with token
             $token = self::generateSecureToken();
+            // Send the confirmation first: if it cannot be delivered, don't
+            // record a pending change the user could never confirm — surface an
+            // honest error instead of a misleading success.
+            if (!self::sendEmailChangeConfirmation($current['email'], $input['email'], $token)) {
+                Response::error('Die Bestätigungs-E-Mail konnte nicht gesendet werden. Bitte versuche es später erneut.', 502);
+                return;
+            }
             $fields[] = 'pending_email = ?';
             $params[] = $input['email'];
             $fields[] = 'email_change_token = ?';
             $params[] = $token;
             $fields[] = 'email_change_requested_at = CURRENT_TIMESTAMP';
-            // send confirmation email
-            self::sendEmailChangeConfirmation($current['email'], $input['email'], $token);
         }
         if (!empty($input['password'])) {
             $fields[] = 'password_hash = ?';
@@ -170,13 +175,17 @@ class UserController
             if (isset($input[$f])) {
                 if ($f === 'email') {
                     $token = self::generateSecureToken();
+                    // Send the confirmation first; abort without recording a
+                    // pending change if it cannot be delivered (see updateMe()).
+                    if (!self::sendEmailChangeConfirmation(null, $input[$f], $token)) {
+                        Response::error('Die Bestätigungs-E-Mail konnte nicht gesendet werden. Bitte versuche es später erneut.', 502);
+                        return;
+                    }
                     $fields[] = 'pending_email = ?';
                     $params[] = $input[$f];
                     $fields[] = 'email_change_token = ?';
                     $params[] = $token;
                     $fields[] = 'email_change_requested_at = CURRENT_TIMESTAMP';
-                    // send confirmation to new email only
-                    self::sendEmailChangeConfirmation(null, $input[$f], $token);
                 } else {
                     $fields[] = "$f = ?";
                     $params[] = $input[$f];
@@ -213,9 +222,9 @@ class UserController
         Response::success(['updated' => true, 'user' => $user], 'User updated');
     }
 
-    private static function sendEmailChangeConfirmation(?string $oldEmail, string $newEmail, string $token): void
+    private static function sendEmailChangeConfirmation(?string $oldEmail, string $newEmail, string $token): bool
     {
-        EmailService::sendEmailChangeConfirmation($oldEmail, $newEmail, $token);
+        return EmailService::sendEmailChangeConfirmation($oldEmail, $newEmail, $token);
     }
 
     private static function generateSecureToken(): string

--- a/backend/src/Middleware/AdminAuth.php
+++ b/backend/src/Middleware/AdminAuth.php
@@ -220,7 +220,7 @@ class AdminAuth
     {
         // Ensure string for DB layer (Prepared Statements akzeptieren beides, wir normalisieren dennoch)
         $idParam = (string)$userId;
-        $sql = "SELECT id, username, email, role, is_active, last_login, created_at, updated_at, twofa_enabled FROM users WHERE id = ?";
+        $sql = "SELECT id, username, email, pending_email, role, is_active, last_login, created_at, updated_at, twofa_enabled FROM users WHERE id = ?";
         $user = Database::fetchOne($sql, [$idParam]);
 
         if (!$user) {
@@ -244,6 +244,7 @@ class AdminAuth
                 'id' => $user['id'],
                 'username' => $user['username'],
                 'email' => $user['email'],
+                'pending_email' => $user['pending_email'] ?? null,
                 'role' => $user['role'],
                 'is_active' => (bool)$user['is_active'],
                 'last_login' => $user['last_login'],

--- a/backend/src/Utils/MockData.php
+++ b/backend/src/Utils/MockData.php
@@ -165,18 +165,23 @@ class MockData
     }
 
     /**
-     * Get mock event categories
+     * Get event categories.
+     *
+     * Mirrors the canonical category ENUM on `events.category` /
+     * `event_series.default_category` (migration 001 + 013) and the
+     * submission allowlist in FormController::validateEventSubmission().
+     * Keep these in sync — this list is served via GET /api/events/meta.
      */
     public static function getCategories(): array
     {
         return [
             'workshop' => 'Workshop',
-            'seminar' => 'Seminar',
             'stammtisch' => 'Stammtisch',
-            'webinar' => 'Webinar',
-            'therapie' => 'Therapie',
-            'ausbildung' => 'Ausbildung',
-            'konferenz' => 'Konferenz'
+            'practice' => 'Praxis',
+            'lecture' => 'Vortrag',
+            'special' => 'Special',
+            'convention' => 'Convention',
+            'party' => 'Party'
         ];
     }
 

--- a/src/components/admin/AdminNotifications.svelte
+++ b/src/components/admin/AdminNotifications.svelte
@@ -74,8 +74,10 @@
   }
 
   function getNotificationClasses(type: string): string {
+    // pointer-events-auto re-enables clicks on the toast itself; the container
+    // is pointer-events-none so its transparent area never blocks the UI.
     const baseClasses =
-      "p-4 rounded-lg shadow-lg border-l-4 transition-all duration-300 ease-in-out";
+      "pointer-events-auto p-4 rounded-lg shadow-lg border-l-4 transition-all duration-300 ease-in-out";
 
     switch (type) {
       case "success":
@@ -108,8 +110,15 @@
 </script>
 
 <!-- Admin Notification Container -->
+<!--
+  Anchored bottom-right (away from the top header) and pointer-events-none so
+  the toast stack can never overlap or block header controls such as the logout
+  button — even while a semi-transparent notification is visible. See #113.
+-->
 {#if adminNotifications.length > 0}
-  <div class="fixed top-4 right-4 z-50 space-y-2 max-w-sm">
+  <div
+    class="pointer-events-none fixed bottom-4 right-4 z-50 space-y-2 max-w-sm"
+  >
     {#each adminNotifications as notification (notification.id)}
       <div
         class={getNotificationClasses(notification.type)}

--- a/src/components/forms/DatePicker.svelte
+++ b/src/components/forms/DatePicker.svelte
@@ -295,7 +295,7 @@
     <Portal>
       {#if isMobile}
         <div
-          class="fixed inset-0 bg-black/50 z-40 animate-fade-in"
+          class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"
           on:click={close}
           on:keydown={(e) => e.key === "Escape" && close()}
           role="button"
@@ -309,7 +309,7 @@
         aria-label="Datum auswählen"
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
-          ? 'fixed inset-x-0 bottom-0 z-50 max-h-[85vh] overflow-y-auto rounded-t-2xl'
+          ? 'fixed inset-x-0 bottom-0 z-[10050] max-h-[85vh] overflow-y-auto rounded-t-2xl'
           : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[300px]"
         style={isMobile ? undefined : pickerStyle}
       >

--- a/src/components/forms/DateTimePicker.svelte
+++ b/src/components/forms/DateTimePicker.svelte
@@ -417,7 +417,7 @@
     <Portal>
       {#if isMobile}
         <div
-          class="fixed inset-0 bg-black/50 z-40 animate-fade-in"
+          class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"
           on:click={close}
           on:keydown={(e) => e.key === "Escape" && close()}
           role="button"
@@ -431,7 +431,7 @@
         aria-label="Datum und Zeit auswählen"
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
-          ? 'fixed inset-x-0 bottom-0 z-50 max-h-[90vh] overflow-y-auto rounded-t-2xl'
+          ? 'fixed inset-x-0 bottom-0 z-[10050] max-h-[90vh] overflow-y-auto rounded-t-2xl'
           : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[320px]"
         style={isMobile ? undefined : pickerStyle}
       >

--- a/src/components/forms/EventSubmissionForm.svelte
+++ b/src/components/forms/EventSubmissionForm.svelte
@@ -38,7 +38,15 @@
     location_url: z.string().url("Ungültige URL").optional().or(z.literal("")),
     location_instructions: z.string().optional(),
     category: z
-      .enum(["workshop", "stammtisch", "practice", "lecture", "special"])
+      .enum([
+        "workshop",
+        "stammtisch",
+        "practice",
+        "lecture",
+        "special",
+        "convention",
+        "party",
+      ])
       .default("stammtisch"),
     difficulty_level: z
       .enum(["beginner", "intermediate", "advanced", "all"])
@@ -418,6 +426,8 @@
           <option value="practice">Praxis-Session</option>
           <option value="lecture">Vortrag</option>
           <option value="special">Besondere Veranstaltung</option>
+          <option value="convention">Convention</option>
+          <option value="party">Party</option>
         </select>
       </div>
 

--- a/src/components/forms/EventSubmissionForm.svelte
+++ b/src/components/forms/EventSubmissionForm.svelte
@@ -423,7 +423,7 @@
         >
           <option value="stammtisch">Stammtisch</option>
           <option value="workshop">Workshop</option>
-          <option value="practice">Praxis-Session</option>
+          <option value="practice">Praxis</option>
           <option value="lecture">Vortrag</option>
           <option value="special">Besondere Veranstaltung</option>
           <option value="convention">Convention</option>

--- a/src/components/forms/TimePicker.svelte
+++ b/src/components/forms/TimePicker.svelte
@@ -263,7 +263,7 @@
     <Portal>
       {#if isMobile}
         <div
-          class="fixed inset-0 bg-black/50 z-40 animate-fade-in"
+          class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"
           on:click={close}
           on:keydown={(e) => e.key === "Escape" && close()}
           role="button"
@@ -277,7 +277,7 @@
         aria-label="Uhrzeit auswählen"
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
-          ? 'fixed inset-x-0 bottom-0 z-50 rounded-t-2xl'
+          ? 'fixed inset-x-0 bottom-0 z-[10050] rounded-t-2xl'
           : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[280px]"
         style={isMobile ? undefined : pickerStyle}
       >

--- a/src/pages/admin/AdminEvents.svelte
+++ b/src/pages/admin/AdminEvents.svelte
@@ -885,6 +885,8 @@
                     <option value="practice">Praxis</option>
                     <option value="lecture">Vortrag</option>
                     <option value="special">Special</option>
+                    <option value="convention">Convention</option>
+                    <option value="party">Party</option>
                   </select>
                 </div>
                 <div>


### PR DESCRIPTION
## Summary

Sammelt 5 Fixes und 1 Feature aus dem dev-Branch:

- **fix(#113):** Notification-Toasts auf `bottom-right` verschoben + `pointer-events-none/-auto`-Trick, damit der Logout-Button nie blockiert wird
- **fix(#114):** E-Mail-Bestätigungsversand fail-fast — `pending_email` wird nur in die DB geschrieben, wenn der Versand geklappt hat (vorher stumme Fehler möglich)
- **fix(#117):** `pending_email` wird nach 2FA-Login korrekt aus `getUserById()` zurückgegeben (SELECT-Feld fehlte)
- **fix(#118):** Datum-/Zeit-Picker auf Mobile über dem Event-Modal sichtbar (`z-40/50` → `z-[10040/10050]`) — konsistent in DatePicker, DateTimePicker, TimePicker
- **feat(#119):** Event-Kategorien „Convention" und „Party" ergänzt — Migration 013 (idempotentes `MODIFY COLUMN`), FormController-Allowlist, MockData, Svelte-Formulare

Außerdem stille Korrektur in `MockData::getCategories()`: Die alten Einträge (`seminar`, `webinar`, `therapie`, `ausbildung`, `konferenz`) waren nie gültige DB-ENUM-Werte — jetzt spiegelt die Liste die echten ENUM-Werte wider.

## Test plan

- [ ] Login (inkl. 2FA) → Admin-Profil aufrufen → `pending_email` wird angezeigt falls gesetzt
- [ ] Admin-Profil → E-Mail ändern → bei funktionierendem Mailserver: Bestätigung kommt; bei defektem SMTP: 502-Fehlermeldung statt stumme Fehler
- [ ] Notification-Toast erscheint rechts unten, überlagert keine Header-Controls (Logout-Button klickbar)
- [ ] Event-Formular auf Mobile → Datum-/Zeit-Picker öffnet sich über dem Modal
- [ ] Event erstellen/bearbeiten → Kategorien „Convention" und „Party" auswählbar
- [ ] Migration 013 läuft sauber durch (Fresh-Install + Update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)