### PR TITLE
fix(admin): Toast-Container über Modals und Picker legen (#124)

### DIFF
--- a/src/components/admin/AdminNotifications.svelte
+++ b/src/components/admin/AdminNotifications.svelte
@@ -117,7 +117,7 @@
 -->
 {#if adminNotifications.length > 0}
   <div
-    class="pointer-events-none fixed bottom-4 right-4 z-50 space-y-2 max-w-sm"
+    class="pointer-events-none fixed bottom-4 right-4 z-[10060] space-y-2 max-w-sm"
   >
     {#each adminNotifications as notification (notification.id)}
       <div


### PR DESCRIPTION
## Übersicht

Der Toast-Container in `AdminNotifications.svelte` verwendete `z-50`. Das Event-Modal in `AdminEvents.svelte` nutzt `z-[9999]`, die Picker-Komponenten `z-[10050]`. Bei offenem Modal waren alle Toasts vollständig verdeckt — schlug im Hintergrund eine Operation fehl (z.B. E-Mail-Versand → 502), sah der Admin kein Feedback.

Closes #124

## Änderung

`z-50` → `z-[10060]` am Toast-Container. Damit liegen Benachrichtigungen über dem Event-Modal **und** den Pickern, sodass Feedback in jeder Situation sichtbar bleibt. Der Container bleibt `pointer-events-none`, blockiert also keine darunterliegenden Controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)