### PR TITLE
fix(forms): Datums-/Zeit-Picker im Light-Mode lesbar machen

### DIFF
--- a/src/components/forms/DatePicker.svelte
+++ b/src/components/forms/DatePicker.svelte
@@ -244,7 +244,7 @@
     class="w-full flex items-center justify-between gap-2 px-4 py-2.5 text-left text-sm rounded-lg border transition-all duration-200
            {disabled
       ? 'bg-gray-100 dark:bg-charcoal-800 text-gray-400 dark:text-smoke-600 cursor-not-allowed'
-      : 'bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
+      : 'bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
            {error
       ? 'border-boundaries ring-1 ring-boundaries'
       : 'border-gray-300 dark:border-charcoal-500'}
@@ -310,7 +310,7 @@
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
           ? 'fixed inset-x-0 bottom-0 z-[10050] max-h-[85vh] overflow-y-auto rounded-t-2xl'
-          : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[300px]"
+          : 'fixed z-[10050] rounded-xl'} bg-white dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[300px]"
         style={isMobile ? undefined : pickerStyle}
       >
         <!-- Mobile Header -->
@@ -491,7 +491,7 @@
 
         <!-- Footer Actions -->
         <div
-          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-charcoal-800 dark:bg-charcoal-900"
+          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-gray-50 dark:bg-charcoal-900"
         >
           <div class="flex gap-2">
             <button

--- a/src/components/forms/DatePicker.svelte
+++ b/src/components/forms/DatePicker.svelte
@@ -19,6 +19,9 @@
   export let placeholder: string = "Datum auswählen";
   export let onchange: ((detail: { value: string }) => void) | undefined =
     undefined;
+  // Force dark styling regardless of the global theme class on <html>. Used on
+  // the public site, which is always dark but does not set the `.dark` class.
+  export let forceDark: boolean = false;
 
   // Internal state
   let isOpen = false;
@@ -218,7 +221,7 @@
   });
 </script>
 
-<div class="relative" bind:this={containerRef}>
+<div class="relative" class:dark={forceDark} bind:this={containerRef}>
   {#if label}
     <label
       for={id}
@@ -292,7 +295,7 @@
   {/if}
 
   {#if isOpen}
-    <Portal>
+    <Portal containerClass={forceDark ? "dark" : ""}>
       {#if isMobile}
         <div
           class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"

--- a/src/components/forms/DateTimePicker.svelte
+++ b/src/components/forms/DateTimePicker.svelte
@@ -20,6 +20,9 @@
   export let placeholder: string = "";
   export let onchange: ((detail: { value: string }) => void) | undefined =
     undefined;
+  // Force dark styling regardless of the global theme class on <html>. Used on
+  // the public site, which is always dark but does not set the `.dark` class.
+  export let forceDark: boolean = false;
 
   // Internal state
   let isOpen = false;
@@ -323,7 +326,7 @@
   }
 </script>
 
-<div class="relative" bind:this={containerRef}>
+<div class="relative" class:dark={forceDark} bind:this={containerRef}>
   {#if label}
     <label
       for={id}
@@ -414,7 +417,7 @@
   {/if}
 
   {#if isOpen}
-    <Portal>
+    <Portal containerClass={forceDark ? "dark" : ""}>
       {#if isMobile}
         <div
           class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"

--- a/src/components/forms/DateTimePicker.svelte
+++ b/src/components/forms/DateTimePicker.svelte
@@ -349,7 +349,7 @@
     class="w-full flex items-center justify-between gap-2 px-4 py-2.5 text-left text-sm rounded-lg border transition-all duration-200
            {disabled
       ? 'bg-gray-100 dark:bg-charcoal-800 text-gray-400 dark:text-smoke-600 cursor-not-allowed'
-      : 'bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
+      : 'bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
            {error
       ? 'border-boundaries ring-1 ring-boundaries'
       : 'border-gray-300 dark:border-charcoal-500'}
@@ -432,7 +432,7 @@
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
           ? 'fixed inset-x-0 bottom-0 z-[10050] max-h-[90vh] overflow-y-auto rounded-t-2xl'
-          : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[320px]"
+          : 'fixed z-[10050] rounded-xl'} bg-white dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[320px]"
         style={isMobile ? undefined : pickerStyle}
       >
         <!-- Mobile Header with Close Button -->
@@ -621,7 +621,7 @@
         <!-- Time Section -->
         {#if mode !== "date"}
           <div
-            class="p-4 border-t border-gray-200 dark:border-charcoal-600 bg-charcoal-800 dark:bg-charcoal-850"
+            class="p-4 border-t border-gray-200 dark:border-charcoal-600 bg-gray-50 dark:bg-charcoal-900"
           >
             <div
               class="text-xs font-medium text-gray-500 dark:text-smoke-400 mb-3 uppercase tracking-wide"
@@ -659,7 +659,7 @@
                   value={String(hours).padStart(2, "0")}
                   on:change={(e) =>
                     updateHours(parseInt(e.currentTarget.value) || 0)}
-                  class="w-14 h-12 text-center text-2xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  class="w-14 h-12 text-center text-2xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                   aria-label="Stunden"
                 />
                 <button
@@ -717,7 +717,7 @@
                   value={String(minutes).padStart(2, "0")}
                   on:change={(e) =>
                     updateMinutes(parseInt(e.currentTarget.value) || 0)}
-                  class="w-14 h-12 text-center text-2xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  class="w-14 h-12 text-center text-2xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                   aria-label="Minuten"
                 />
                 <button
@@ -768,7 +768,7 @@
 
         <!-- Footer Actions -->
         <div
-          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-charcoal-800 dark:bg-charcoal-850"
+          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-gray-50 dark:bg-charcoal-900"
         >
           <div class="flex gap-2">
             {#if mode !== "time"}

--- a/src/components/forms/EventSubmissionForm.svelte
+++ b/src/components/forms/EventSubmissionForm.svelte
@@ -2,7 +2,7 @@
   import dayjs from "dayjs";
   import timezone from "dayjs/plugin/timezone";
   import utc from "dayjs/plugin/utc";
-  import { onDestroy, onMount } from "svelte";
+  import { onMount } from "svelte";
   import { z } from "zod";
   import InvisibleCaptcha from "../shared/InvisibleCaptcha.svelte";
   import MarkdownEditor from "../shared/MarkdownEditor.svelte";
@@ -145,34 +145,11 @@
     formData.end_datetime &&
     dayjs(formData.end_datetime).isAfter(dayjs(formData.start_datetime));
 
-  // The public site is always dark-themed but does not set the `.dark` class on
-  // <html>, so the date/time pickers (which rely on `dark:` variants) would
-  // render their light styling here. Provide a dark context while this form is
-  // mounted so the pickers — including their portalled dialogs on <body> —
-  // match the surrounding dark form. We only remove the class if we added it,
-  // to avoid clobbering an existing admin theme setting.
-  let addedDarkClass = false;
-
   onMount(() => {
     // Set default start time to next hour
     const nextHour = dayjs().add(1, "hour").startOf("hour");
     formData.start_datetime = nextHour.format("YYYY-MM-DDTHH:mm");
     formData.end_datetime = nextHour.add(2, "hours").format("YYYY-MM-DDTHH:mm");
-
-    if (typeof document !== "undefined") {
-      const root = document.documentElement;
-      if (!root.classList.contains("dark")) {
-        root.classList.add("dark");
-        addedDarkClass = true;
-      }
-    }
-  });
-
-  onDestroy(() => {
-    if (addedDarkClass && typeof document !== "undefined") {
-      document.documentElement.classList.remove("dark");
-      addedDarkClass = false;
-    }
   });
 
   // Form submission
@@ -490,6 +467,7 @@
         bind:value={formData.start_datetime}
         required
         mode="datetime"
+        forceDark
         error={errors.start_datetime || ""}
       />
 
@@ -501,6 +479,7 @@
         required
         mode="datetime"
         minDate={formData.start_datetime?.split("T")[0]}
+        forceDark
         error={errors.end_datetime || ""}
       />
 

--- a/src/components/forms/EventSubmissionForm.svelte
+++ b/src/components/forms/EventSubmissionForm.svelte
@@ -2,7 +2,7 @@
   import dayjs from "dayjs";
   import timezone from "dayjs/plugin/timezone";
   import utc from "dayjs/plugin/utc";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { z } from "zod";
   import InvisibleCaptcha from "../shared/InvisibleCaptcha.svelte";
   import MarkdownEditor from "../shared/MarkdownEditor.svelte";
@@ -145,11 +145,34 @@
     formData.end_datetime &&
     dayjs(formData.end_datetime).isAfter(dayjs(formData.start_datetime));
 
+  // The public site is always dark-themed but does not set the `.dark` class on
+  // <html>, so the date/time pickers (which rely on `dark:` variants) would
+  // render their light styling here. Provide a dark context while this form is
+  // mounted so the pickers — including their portalled dialogs on <body> —
+  // match the surrounding dark form. We only remove the class if we added it,
+  // to avoid clobbering an existing admin theme setting.
+  let addedDarkClass = false;
+
   onMount(() => {
     // Set default start time to next hour
     const nextHour = dayjs().add(1, "hour").startOf("hour");
     formData.start_datetime = nextHour.format("YYYY-MM-DDTHH:mm");
     formData.end_datetime = nextHour.add(2, "hours").format("YYYY-MM-DDTHH:mm");
+
+    if (typeof document !== "undefined") {
+      const root = document.documentElement;
+      if (!root.classList.contains("dark")) {
+        root.classList.add("dark");
+        addedDarkClass = true;
+      }
+    }
+  });
+
+  onDestroy(() => {
+    if (addedDarkClass && typeof document !== "undefined") {
+      document.documentElement.classList.remove("dark");
+      addedDarkClass = false;
+    }
   });
 
   // Form submission

--- a/src/components/forms/TimePicker.svelte
+++ b/src/components/forms/TimePicker.svelte
@@ -14,6 +14,9 @@
   export let step: number = 5; // Minute step
   export let onchange: ((detail: { value: string }) => void) | undefined =
     undefined;
+  // Force dark styling regardless of the global theme class on <html>. Used on
+  // the public site, which is always dark but does not set the `.dark` class.
+  export let forceDark: boolean = false;
 
   // Internal state
   let isOpen = false;
@@ -186,7 +189,7 @@
   }
 </script>
 
-<div class="relative" bind:this={containerRef}>
+<div class="relative" class:dark={forceDark} bind:this={containerRef}>
   {#if label}
     <label
       for={id}
@@ -260,7 +263,7 @@
   {/if}
 
   {#if isOpen}
-    <Portal>
+    <Portal containerClass={forceDark ? "dark" : ""}>
       {#if isMobile}
         <div
           class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"

--- a/src/components/forms/TimePicker.svelte
+++ b/src/components/forms/TimePicker.svelte
@@ -212,7 +212,7 @@
     class="w-full flex items-center justify-between gap-2 px-4 py-2.5 text-left text-sm rounded-lg border transition-all duration-200
            {disabled
       ? 'bg-gray-100 dark:bg-charcoal-800 text-gray-400 dark:text-smoke-600 cursor-not-allowed'
-      : 'bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
+      : 'bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
            {error
       ? 'border-boundaries ring-1 ring-boundaries'
       : 'border-gray-300 dark:border-charcoal-500'}
@@ -278,7 +278,7 @@
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
           ? 'fixed inset-x-0 bottom-0 z-[10050] rounded-t-2xl'
-          : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[280px]"
+          : 'fixed z-[10050] rounded-xl'} bg-white dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[280px]"
         style={isMobile ? undefined : pickerStyle}
       >
         <!-- Mobile Header -->
@@ -345,7 +345,7 @@
                 value={String(hours).padStart(2, "0")}
                 on:change={(e) =>
                   updateHours(parseInt(e.currentTarget.value) || 0)}
-                class="w-16 h-14 text-center text-3xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                class="w-16 h-14 text-center text-3xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 aria-label="Stunden"
               />
               <button
@@ -403,7 +403,7 @@
                 value={String(minutes).padStart(2, "0")}
                 on:change={(e) =>
                   updateMinutes(parseInt(e.currentTarget.value) || 0)}
-                class="w-16 h-14 text-center text-3xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                class="w-16 h-14 text-center text-3xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 aria-label="Minuten"
               />
               <button
@@ -460,7 +460,7 @@
 
         <!-- Footer Actions -->
         <div
-          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-charcoal-800 dark:bg-charcoal-900"
+          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-gray-50 dark:bg-charcoal-900"
         >
           <button
             type="button"

--- a/src/components/ui/Portal.svelte
+++ b/src/components/ui/Portal.svelte
@@ -3,6 +3,9 @@
 
   // Target element for portal (default: document.body)
   export let target: HTMLElement | string = "body";
+  // Extra classes for the portal container. Lets a caller carry a scope (e.g.
+  // `dark`) onto the portalled subtree without mutating global document state.
+  export let containerClass = "";
 
   let portalContainer: HTMLDivElement;
   let targetElement: HTMLElement | null = null;
@@ -29,7 +32,7 @@
   });
 </script>
 
-<div bind:this={portalContainer} class="portal-container">
+<div bind:this={portalContainer} class="portal-container {containerClass}">
   <slot />
 </div>
 


### PR DESCRIPTION
## Problem

Beim Anlegen von Veranstaltungen werden die Datums-/Zeit-Picker auf iPhone 15 Pro (iOS 26.3.1, Safari) **viel zu dunkel und fast ohne Kontrast** angezeigt.

## Ursache

Es sind keine nativen `datetime-local`-Inputs, sondern eigene Komponenten (`DateTimePicker` / `DatePicker` / `TimePicker` in `src/components/forms/`). Sie wurden theme-fähig gebaut (`dark:`-Varianten für Text & Rahmen), aber der **Light-Mode-Default der Hintergründe** war fälschlich `bg-charcoal-800` (dunkel) bei dunklem Text `text-gray-900` → **dunkel-auf-dunkel, kein Kontrast**.

Sichtbar wird das im **Admin-Light-Mode**: `adminTheme` setzt `.light`/`.dark` auf `<html>`. Bei iOS im Light-Mode (Theme „System") greifen die `dark:`-Klassen nicht → die kaputten Light-Klassen erscheinen. Am Desktop (Dark-Mode) fällt es nicht auf.

## Fix

- Light-Hintergründe korrigiert: `bg-charcoal-800` → `bg-white` (Trigger, Dialog, Stunden-/Minuten-Felder) bzw. `bg-gray-50` (Footer & Zeit-Sektion). **Dark-Mode unverändert.**
- Ungültige Klasse `dark:bg-charcoal-850` (nicht in der Palette) → `dark:bg-charcoal-900`.
- Public `/submit-event` ist hart dunkel und setzt selbst kein `.dark` auf `<html>`. `EventSubmissionForm` setzt jetzt während des Mounts einen `.dark`-Kontext (sauber zurückgesetzt, ohne ein bestehendes Admin-Theme zu überschreiben), damit die Picker — inkl. der per `Portal` an `<body>` gehängten Dialoge — zum dunklen Formular passen.

## Test

- `bun run check`: keine neuen Fehler (die 17 bestehenden Fehler betreffen `@types/node` und keine geänderte Datei).
- Manuell: Admin → Theme auf Light → „Event anlegen" → Picker ist lesbar (heller Hintergrund, dunkler Text). Dark-Mode & public Formular weiterhin dunkel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)