### PR TITLE
fix(forms): Datums-/Zeit-Picker im Light-Mode lesbar machen (#137)

### DIFF
--- a/src/components/forms/DatePicker.svelte
+++ b/src/components/forms/DatePicker.svelte
@@ -19,6 +19,9 @@
   export let placeholder: string = "Datum auswählen";
   export let onchange: ((detail: { value: string }) => void) | undefined =
     undefined;
+  // Force dark styling regardless of the global theme class on <html>. Used on
+  // the public site, which is always dark but does not set the `.dark` class.
+  export let forceDark: boolean = false;
 
   // Internal state
   let isOpen = false;
@@ -218,7 +221,7 @@
   });
 </script>
 
-<div class="relative" bind:this={containerRef}>
+<div class="relative" class:dark={forceDark} bind:this={containerRef}>
   {#if label}
     <label
       for={id}
@@ -244,7 +247,7 @@
     class="w-full flex items-center justify-between gap-2 px-4 py-2.5 text-left text-sm rounded-lg border transition-all duration-200
            {disabled
       ? 'bg-gray-100 dark:bg-charcoal-800 text-gray-400 dark:text-smoke-600 cursor-not-allowed'
-      : 'bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
+      : 'bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
            {error
       ? 'border-boundaries ring-1 ring-boundaries'
       : 'border-gray-300 dark:border-charcoal-500'}
@@ -292,7 +295,7 @@
   {/if}
 
   {#if isOpen}
-    <Portal>
+    <Portal containerClass={forceDark ? "dark" : ""}>
       {#if isMobile}
         <div
           class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"
@@ -310,7 +313,7 @@
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
           ? 'fixed inset-x-0 bottom-0 z-[10050] max-h-[85vh] overflow-y-auto rounded-t-2xl'
-          : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[300px]"
+          : 'fixed z-[10050] rounded-xl'} bg-white dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[300px]"
         style={isMobile ? undefined : pickerStyle}
       >
         <!-- Mobile Header -->
@@ -491,7 +494,7 @@
 
         <!-- Footer Actions -->
         <div
-          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-charcoal-800 dark:bg-charcoal-900"
+          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-gray-50 dark:bg-charcoal-900"
         >
           <div class="flex gap-2">
             <button

--- a/src/components/forms/DateTimePicker.svelte
+++ b/src/components/forms/DateTimePicker.svelte
@@ -20,6 +20,9 @@
   export let placeholder: string = "";
   export let onchange: ((detail: { value: string }) => void) | undefined =
     undefined;
+  // Force dark styling regardless of the global theme class on <html>. Used on
+  // the public site, which is always dark but does not set the `.dark` class.
+  export let forceDark: boolean = false;
 
   // Internal state
   let isOpen = false;
@@ -323,7 +326,7 @@
   }
 </script>
 
-<div class="relative" bind:this={containerRef}>
+<div class="relative" class:dark={forceDark} bind:this={containerRef}>
   {#if label}
     <label
       for={id}
@@ -349,7 +352,7 @@
     class="w-full flex items-center justify-between gap-2 px-4 py-2.5 text-left text-sm rounded-lg border transition-all duration-200
            {disabled
       ? 'bg-gray-100 dark:bg-charcoal-800 text-gray-400 dark:text-smoke-600 cursor-not-allowed'
-      : 'bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
+      : 'bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
            {error
       ? 'border-boundaries ring-1 ring-boundaries'
       : 'border-gray-300 dark:border-charcoal-500'}
@@ -414,7 +417,7 @@
   {/if}
 
   {#if isOpen}
-    <Portal>
+    <Portal containerClass={forceDark ? "dark" : ""}>
       {#if isMobile}
         <div
           class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"
@@ -432,7 +435,7 @@
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
           ? 'fixed inset-x-0 bottom-0 z-[10050] max-h-[90vh] overflow-y-auto rounded-t-2xl'
-          : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[320px]"
+          : 'fixed z-[10050] rounded-xl'} bg-white dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[320px]"
         style={isMobile ? undefined : pickerStyle}
       >
         <!-- Mobile Header with Close Button -->
@@ -621,7 +624,7 @@
         <!-- Time Section -->
         {#if mode !== "date"}
           <div
-            class="p-4 border-t border-gray-200 dark:border-charcoal-600 bg-charcoal-800 dark:bg-charcoal-850"
+            class="p-4 border-t border-gray-200 dark:border-charcoal-600 bg-gray-50 dark:bg-charcoal-900"
           >
             <div
               class="text-xs font-medium text-gray-500 dark:text-smoke-400 mb-3 uppercase tracking-wide"
@@ -659,7 +662,7 @@
                   value={String(hours).padStart(2, "0")}
                   on:change={(e) =>
                     updateHours(parseInt(e.currentTarget.value) || 0)}
-                  class="w-14 h-12 text-center text-2xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  class="w-14 h-12 text-center text-2xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                   aria-label="Stunden"
                 />
                 <button
@@ -717,7 +720,7 @@
                   value={String(minutes).padStart(2, "0")}
                   on:change={(e) =>
                     updateMinutes(parseInt(e.currentTarget.value) || 0)}
-                  class="w-14 h-12 text-center text-2xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  class="w-14 h-12 text-center text-2xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                   aria-label="Minuten"
                 />
                 <button
@@ -768,7 +771,7 @@
 
         <!-- Footer Actions -->
         <div
-          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-charcoal-800 dark:bg-charcoal-850"
+          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-gray-50 dark:bg-charcoal-900"
         >
           <div class="flex gap-2">
             {#if mode !== "time"}

--- a/src/components/forms/EventSubmissionForm.svelte
+++ b/src/components/forms/EventSubmissionForm.svelte
@@ -467,6 +467,7 @@
         bind:value={formData.start_datetime}
         required
         mode="datetime"
+        forceDark
         error={errors.start_datetime || ""}
       />
 
@@ -478,6 +479,7 @@
         required
         mode="datetime"
         minDate={formData.start_datetime?.split("T")[0]}
+        forceDark
         error={errors.end_datetime || ""}
       />
 

--- a/src/components/forms/TimePicker.svelte
+++ b/src/components/forms/TimePicker.svelte
@@ -14,6 +14,9 @@
   export let step: number = 5; // Minute step
   export let onchange: ((detail: { value: string }) => void) | undefined =
     undefined;
+  // Force dark styling regardless of the global theme class on <html>. Used on
+  // the public site, which is always dark but does not set the `.dark` class.
+  export let forceDark: boolean = false;
 
   // Internal state
   let isOpen = false;
@@ -186,7 +189,7 @@
   }
 </script>
 
-<div class="relative" bind:this={containerRef}>
+<div class="relative" class:dark={forceDark} bind:this={containerRef}>
   {#if label}
     <label
       for={id}
@@ -212,7 +215,7 @@
     class="w-full flex items-center justify-between gap-2 px-4 py-2.5 text-left text-sm rounded-lg border transition-all duration-200
            {disabled
       ? 'bg-gray-100 dark:bg-charcoal-800 text-gray-400 dark:text-smoke-600 cursor-not-allowed'
-      : 'bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
+      : 'bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 cursor-pointer hover:border-primary-400 dark:hover:border-primary-500'}
            {error
       ? 'border-boundaries ring-1 ring-boundaries'
       : 'border-gray-300 dark:border-charcoal-500'}
@@ -260,7 +263,7 @@
   {/if}
 
   {#if isOpen}
-    <Portal>
+    <Portal containerClass={forceDark ? "dark" : ""}>
       {#if isMobile}
         <div
           class="fixed inset-0 bg-black/50 z-[10040] animate-fade-in"
@@ -278,7 +281,7 @@
         aria-modal={isMobile ? "true" : undefined}
         class="{isMobile
           ? 'fixed inset-x-0 bottom-0 z-[10050] rounded-t-2xl'
-          : 'fixed z-[10050] rounded-xl'} bg-charcoal-800 dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[280px]"
+          : 'fixed z-[10050] rounded-xl'} bg-white dark:bg-charcoal-800 shadow-xl border border-gray-200 dark:border-charcoal-600 overflow-hidden animate-fade-in sm:min-w-[280px]"
         style={isMobile ? undefined : pickerStyle}
       >
         <!-- Mobile Header -->
@@ -345,7 +348,7 @@
                 value={String(hours).padStart(2, "0")}
                 on:change={(e) =>
                   updateHours(parseInt(e.currentTarget.value) || 0)}
-                class="w-16 h-14 text-center text-3xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                class="w-16 h-14 text-center text-3xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 aria-label="Stunden"
               />
               <button
@@ -403,7 +406,7 @@
                 value={String(minutes).padStart(2, "0")}
                 on:change={(e) =>
                   updateMinutes(parseInt(e.currentTarget.value) || 0)}
-                class="w-16 h-14 text-center text-3xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-charcoal-800 dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                class="w-16 h-14 text-center text-3xl font-bold rounded-lg border border-gray-300 dark:border-charcoal-500 bg-white dark:bg-charcoal-700 text-gray-900 dark:text-smoke-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 aria-label="Minuten"
               />
               <button
@@ -460,7 +463,7 @@
 
         <!-- Footer Actions -->
         <div
-          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-charcoal-800 dark:bg-charcoal-900"
+          class="flex items-center justify-between gap-2 p-3 border-t border-gray-200 dark:border-charcoal-600 bg-gray-50 dark:bg-charcoal-900"
         >
           <button
             type="button"

--- a/src/components/ui/Portal.svelte
+++ b/src/components/ui/Portal.svelte
@@ -3,6 +3,9 @@
 
   // Target element for portal (default: document.body)
   export let target: HTMLElement | string = "body";
+  // Extra classes for the portal container. Lets a caller carry a scope (e.g.
+  // `dark`) onto the portalled subtree without mutating global document state.
+  export let containerClass = "";
 
   let portalContainer: HTMLDivElement;
   let targetElement: HTMLElement | null = null;
@@ -29,7 +32,7 @@
   });
 </script>
 
-<div bind:this={portalContainer} class="portal-container">
+<div bind:this={portalContainer} class="portal-container {containerClass}">
   <slot />
 </div>
 


### PR DESCRIPTION
* fix(forms): Datums-/Zeit-Picker im Light-Mode lesbar machen

Die Picker (DateTimePicker/DatePicker/TimePicker) wurden mit dark:-Varianten gebaut, aber der Light-Mode-Default der Hintergruende war faelschlich bg-charcoal-800 (dunkel) bei dunklem Text (text-gray-900) -> kein Kontrast. Sichtbar im Admin-Light-Mode (z.B. iPhone/iOS system=light), wo .light auf <html> gesetzt wird und die dark:-Klassen nicht greifen.

- Light-Hintergruende auf bg-white bzw. bg-gray-50 korrigiert (Trigger, Dialog, Stunden-/Minuten-Felder, Footer, Zeit-Sektion)
- Ungueltige Klasse dark:bg-charcoal-850 auf dark:bg-charcoal-900 gefixt
- Public /submit-event ist hart dunkel ohne .dark auf <html>: EventSubmissionForm setzt jetzt waehrend des Mounts einen .dark-Kontext, damit die Picker (inkl. der per Portal an <body> gehaengten Dialoge) zum dunklen Formular passen

Dark-Mode bleibt unveraendert.



* refactor(forms): Picker-Dark-Kontext scopen statt global togglen

Code-Review-Finding: EventSubmissionForm mutierte document.documentElement global (.dark auf <html>), um nur die Picker dunkel zu stylen. Das wirkte dokumentweit (z.B. CookieBanner-Backdrop) und ist ein fragiler Bandaid.

Stattdessen: forceDark-Prop an DateTimePicker/DatePicker/TimePicker. Es setzt .dark auf den Trigger-Container und reicht via neuer Portal-Prop containerClass den Dark-Scope an den per Portal ausgelagerten Dialog weiter (.dark auf dem display:contents-Container -> dark:-Varianten der Nachfahren greifen). Kein Eingriff in globalen Theme-State mehr.

- Portal: optionale containerClass-Prop (additiv, abwaertskompatibel)
- EventSubmissionForm: globalen onMount/onDestroy-Toggle entfernt, forceDark an beide DateTimePicker uebergeben
- Admin-Nutzung unveraendert (forceDark default false -> theme-gesteuert)

